### PR TITLE
Proxy spike.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,8 @@ AllCops:
   - vendor/**/*
 HandleExceptions:
   Enabled: false
+Metrics/ClassLength:
+  Max: 150
 MultilineOperationIndentation:
   Enabled: false
 PercentLiteralDelimiters:

--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -109,6 +109,23 @@ module ActiveInteraction
         initialize_filter(klass.new(name, options, &block))
       end
 
+      # @since 2.0.0
+      def proxy(name, inputs)
+        (@_proxies ||= Set.new).add(name)
+
+        attr_reader name
+
+        inputs.each do |input|
+          define_method(input) do
+            send(name).send(input)
+          end
+
+          define_method("#{input}=") do |value|
+            send(name).send("#{input}=", value)
+          end
+        end
+      end
+
       # Import filters from another interaction.
       #
       # @param klass [Class] The other interaction.
@@ -156,6 +173,7 @@ module ActiveInteraction
     def initialize(inputs = {})
       fail ArgumentError, 'inputs must be a hash' unless inputs.is_a?(Hash)
 
+      process_proxies(self.class.instance_variable_get(:@_proxies) || Set.new)
       process_inputs(inputs.symbolize_keys)
     end
 
@@ -252,6 +270,13 @@ module ActiveInteraction
         Validation.validate(self.class.filters, inputs).each do |error|
           errors.add_sym(*error)
         end
+      end
+    end
+
+    def process_proxies(proxies)
+      proxies.each do |name|
+        klass = name.to_s.camelize.constantize.new
+        instance_variable_set("@#{name}", klass)
       end
     end
   end

--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -110,18 +110,18 @@ module ActiveInteraction
       end
 
       # @since 2.0.0
-      def proxy(name, inputs)
+      def proxy(name, mapping)
         (@_proxies ||= Set.new).add(name)
 
         attr_reader name
 
-        inputs.each do |input|
-          define_method(input) do
-            send(name).send(input)
+        mapping.each do |to, from|
+          define_method(from) do
+            send(name).send(to)
           end
 
-          define_method("#{input}=") do |value|
-            send(name).send("#{input}=", value)
+          define_method("#{from}=") do |value|
+            send(name).send("#{to}=", value)
           end
         end
       end

--- a/spec/active_interaction/base_spec.rb
+++ b/spec/active_interaction/base_spec.rb
@@ -18,6 +18,16 @@ AddInteraction = Class.new(TestInteraction) do
   end
 end
 
+ProxyInteraction = Class.new(TestInteraction) do
+  float :x, :y
+
+  proxy :add_interaction, %i[x y]
+
+  def execute
+    add_interaction.run!
+  end
+end
+
 InterruptInteraction = Class.new(TestInteraction) do
   model :x, :y,
     class: Object,
@@ -344,6 +354,17 @@ describe ActiveInteraction::Base do
 
     it 'strips non-filtered inputs' do
       expect(interaction.inputs).to_not have_key(:other)
+    end
+  end
+
+  describe '#proxy' do
+    let(:described_class) { ProxyInteraction }
+    let(:x) { rand }
+    let(:y) { rand }
+    let(:inputs) { { x: x, y: y } }
+
+    it 'works' do
+      expect(result).to eql x + y
     end
   end
 

--- a/spec/active_interaction/base_spec.rb
+++ b/spec/active_interaction/base_spec.rb
@@ -19,9 +19,11 @@ AddInteraction = Class.new(TestInteraction) do
 end
 
 ProxyInteraction = Class.new(TestInteraction) do
-  float :x, :y
+  float :a, :b
 
-  proxy :add_interaction, [:x, :y]
+  proxy :add_interaction,
+    x: :a,
+    y: :b
 
   def execute
     add_interaction.run!
@@ -359,12 +361,12 @@ describe ActiveInteraction::Base do
 
   describe '#proxy' do
     let(:described_class) { ProxyInteraction }
-    let(:x) { rand }
-    let(:y) { rand }
-    let(:inputs) { { x: x, y: y } }
+    let(:a) { rand }
+    let(:b) { rand }
+    let(:inputs) { { a: a, b: b } }
 
     it 'works' do
-      expect(result).to eql x + y
+      expect(result).to eql a + b
     end
   end
 

--- a/spec/active_interaction/base_spec.rb
+++ b/spec/active_interaction/base_spec.rb
@@ -21,7 +21,7 @@ end
 ProxyInteraction = Class.new(TestInteraction) do
   float :x, :y
 
-  proxy :add_interaction, %i[x y]
+  proxy :add_interaction, [:x, :y]
 
   def execute
     add_interaction.run!


### PR DESCRIPTION
A swing at  #245.

This PR is an example of how proxying to another model or interaction might behave. The general idea would be to proxy inputs to the underlying model/interaction. Ultimately the model would also validate the inputs and those validations would be merged into the containing interaction.