### PR TITLE
Pass interaction to default procs

### DIFF
--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -263,7 +263,7 @@ module ActiveInteraction
     def populate_filters(inputs)
       self.class.filters.each do |name, filter|
         begin
-          public_send("#{name}=", filter.clean(inputs[name]))
+          public_send("#{name}=", filter.clean(inputs[name], self))
         rescue InvalidValueError, MissingValueError, InvalidNestedValueError
           # #type_check will add errors if appropriate.
         end

--- a/lib/active_interaction/filter.rb
+++ b/lib/active_interaction/filter.rb
@@ -95,10 +95,10 @@ module ActiveInteraction
     #
     # @raise (see #cast)
     # @raise (see #default)
-    def clean(value)
+    def clean(value, interaction = nil)
       value = cast(value)
       if value.nil?
-        default
+        default(interaction)
       else
         value
       end
@@ -120,10 +120,10 @@ module ActiveInteraction
     #
     # @raise [NoDefaultError] If the default is missing.
     # @raise [InvalidDefaultError] If the default is invalid.
-    def default
+    def default(interaction = nil)
       fail NoDefaultError, name unless default?
 
-      value = raw_default
+      value = raw_default(interaction)
       fail InvalidValueError if value.is_a?(GroupedInput)
 
       cast(value)
@@ -204,11 +204,15 @@ module ActiveInteraction
     end
 
     # @return [Object]
-    def raw_default
+    def raw_default(interaction)
       value = options.fetch(:default)
 
       if value.is_a?(Proc)
-        value.call
+        if value.arity == 1
+          value.call(interaction) if interaction
+        else
+          value.call
+        end
       else
         value
       end

--- a/lib/active_interaction/filters/hash_filter.rb
+++ b/lib/active_interaction/filters/hash_filter.rb
@@ -60,7 +60,7 @@ module ActiveInteraction
       raise InvalidNestedValueError.new(name, value[name])
     end
 
-    def raw_default
+    def raw_default(*)
       value = super
 
       if value.is_a?(Hash) && !value.empty?


### PR DESCRIPTION
Fixes #217. Example usage:

``` rb
class Example < ActiveInteraction::Base
  string :a
  string :b,
    default: 'b'
  string :c,
    default: -> { 'c' }
  string :d,
    default: -> this { [this.a, this.b, this.c].join(' ') }

  def execute
    inputs
  end
end

p Example.new.inputs
# {:a=>nil, :b=>"b", :c=>"c", :d=>"b c"}
p Example.run!(a: 'a')
# {:a=>"a", :b=>"b", :c=>"c", :d=>"a b c"}
```

Edit: An alternative to #221, #222, and #231. 