### PR TITLE
Improve invalid nested value error message

### DIFF
--- a/lib/active_interaction/errors.rb
+++ b/lib/active_interaction/errors.rb
@@ -67,7 +67,7 @@ module ActiveInteraction
     # @param filter_name [Symbol]
     # @param input_value [Object]
     def initialize(filter_name, input_value)
-      super()
+      super("#{filter_name}: #{input_value.inspect}")
 
       @filter_name = filter_name
       @input_value = input_value


### PR DESCRIPTION
This pull request is in response to #255. When you define a hash with `default: {}`, we eagerly build the default value. If one of the inputs inside that hash doesn't have a default, you'll get an error. For example:

``` rb
class Example < ActiveInteraction::Base
  hash :x, default: {} do
    string :y
  end
end
# ActiveInteraction::InvalidNestedValueError: ActiveInteraction::InvalidNestedValueError
```

Since there's no error message, it's basically useless. This pull request adds a message to that error. Now it looks like this:

``` rb
class Example < ActiveInteraction::Base
  hash :x, default: {} do
    string :y
  end
end
# ActiveInteraction::InvalidNestedValueError: y: nil
```

Can you review this, @AaronLasseigne? 