### PR TITLE
Evaluate default lambdas in the context of the interaction instance

### DIFF
--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -214,7 +214,7 @@ module ActiveInteraction
     def populate_filters(inputs)
       self.class.filters.each do |name, filter|
         begin
-          public_send("#{name}=", filter.clean(inputs[name]))
+          public_send("#{name}=", filter.clean(inputs[name], self))
         rescue InvalidValueError, MissingValueError, InvalidNestedValueError
           # #type_check will add errors if appropriate.
         end

--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -146,8 +146,6 @@ module ActiveInteraction
 
         attr_accessor filter.name
         define_method("#{filter.name}?") { !public_send(filter.name).nil? }
-
-        filter.default if filter.default?
       end
     end
 

--- a/lib/active_interaction/filter.rb
+++ b/lib/active_interaction/filter.rb
@@ -95,10 +95,10 @@ module ActiveInteraction
     #
     # @raise (see #cast)
     # @raise (see #default)
-    def clean(value)
+    def clean(value, interaction)
       value = cast(value)
       if value.nil?
-        default
+        default(interaction)
       else
         value
       end
@@ -120,10 +120,10 @@ module ActiveInteraction
     #
     # @raise [NoDefaultError] If the default is missing.
     # @raise [InvalidDefaultError] If the default is invalid.
-    def default
+    def default(interaction)
       fail NoDefaultError, name unless default?
 
-      value = raw_default
+      value = raw_default(interaction)
       fail InvalidValueError if value.is_a?(GroupedInput)
 
       cast(value)
@@ -204,11 +204,11 @@ module ActiveInteraction
     end
 
     # @return [Object]
-    def raw_default
+    def raw_default(interaction)
       value = options.fetch(:default)
 
       if value.is_a?(Proc)
-        value.call
+        interaction.instance_exec(&value)
       else
         value
       end

--- a/lib/active_interaction/filters/array_filter.rb
+++ b/lib/active_interaction/filters/array_filter.rb
@@ -38,7 +38,7 @@ module ActiveInteraction
         return value if filters.empty?
 
         filter = filters.values.first
-        value.map { |e| filter.clean(e, nil) } # TODO
+        value.map { |e| filter.cast(e) }
       else
         super
       end

--- a/lib/active_interaction/filters/array_filter.rb
+++ b/lib/active_interaction/filters/array_filter.rb
@@ -38,7 +38,7 @@ module ActiveInteraction
         return value if filters.empty?
 
         filter = filters.values.first
-        value.map { |e| filter.clean(e) }
+        value.map { |e| filter.clean(e, nil) } # TODO
       else
         super
       end

--- a/lib/active_interaction/filters/hash_filter.rb
+++ b/lib/active_interaction/filters/hash_filter.rb
@@ -52,12 +52,12 @@ module ActiveInteraction
     private
 
     def clean_value(h, name, filter, value)
-      h[name] = filter.clean(value[name])
+      h[name] = filter.clean(value[name], nil) # TODO
     rescue InvalidValueError, MissingValueError
       raise InvalidNestedValueError.new(name, value[name])
     end
 
-    def raw_default
+    def raw_default(*)
       value = super
 
       if value.is_a?(Hash) && !value.empty?

--- a/spec/active_interaction/filters/date_filter_spec.rb
+++ b/spec/active_interaction/filters/date_filter_spec.rb
@@ -127,7 +127,7 @@ describe ActiveInteraction::DateFilter, :filter do
 
       it 'raises an error' do
         expect do
-          filter.default
+          filter.default(nil)
         end.to raise_error ActiveInteraction::InvalidDefaultError
       end
     end

--- a/spec/active_interaction/filters/date_time_filter_spec.rb
+++ b/spec/active_interaction/filters/date_time_filter_spec.rb
@@ -138,7 +138,7 @@ describe ActiveInteraction::DateTimeFilter, :filter do
 
       it 'raises an error' do
         expect do
-          filter.default
+          filter.default(nil)
         end.to raise_error ActiveInteraction::InvalidDefaultError
       end
     end

--- a/spec/active_interaction/filters/hash_filter_spec.rb
+++ b/spec/active_interaction/filters/hash_filter_spec.rb
@@ -84,7 +84,7 @@ describe ActiveInteraction::HashFilter, :filter do
       end
 
       it 'returns the Hash' do
-        expect(filter.default).to eql options[:default]
+        expect(filter.default(nil)).to eql options[:default]
       end
     end
 
@@ -95,7 +95,7 @@ describe ActiveInteraction::HashFilter, :filter do
 
       it 'raises an error' do
         expect do
-          filter.default
+          filter.default(nil)
         end.to raise_error ActiveInteraction::InvalidDefaultError
       end
     end

--- a/spec/active_interaction/filters/time_filter_spec.rb
+++ b/spec/active_interaction/filters/time_filter_spec.rb
@@ -160,7 +160,7 @@ describe ActiveInteraction::TimeFilter, :filter do
 
       it 'raises an error' do
         expect do
-          filter.default
+          filter.default(nil)
         end.to raise_error ActiveInteraction::InvalidDefaultError
       end
     end

--- a/spec/active_interaction/integration/array_interaction_spec.rb
+++ b/spec/active_interaction/integration/array_interaction_spec.rb
@@ -28,26 +28,4 @@ describe ArrayInteraction do
       expect(result[:b]).to eql [[]]
     end
   end
-
-  context 'with an invalid default' do
-    it 'raises an error' do
-      expect do
-        Class.new(ActiveInteraction::Base) do
-          array :a, default: Object.new
-        end
-      end.to raise_error ActiveInteraction::InvalidDefaultError
-    end
-  end
-
-  context 'with an invalid nested default' do
-    it 'raises an error' do
-      expect do
-        Class.new(ActiveInteraction::Base) do
-          array :a, default: [Object.new] do
-            array
-          end
-        end
-      end.to raise_error ActiveInteraction::InvalidDefaultError
-    end
-  end
 end

--- a/spec/active_interaction/integration/hash_interaction_spec.rb
+++ b/spec/active_interaction/integration/hash_interaction_spec.rb
@@ -28,26 +28,4 @@ describe HashInteraction do
       expect(result[:b]).to eql('x' => {})
     end
   end
-
-  context 'with an invalid default' do
-    it 'raises an error' do
-      expect do
-        Class.new(ActiveInteraction::Base) do
-          hash :a, default: Object.new
-        end
-      end.to raise_error ActiveInteraction::InvalidDefaultError
-    end
-  end
-
-  context 'with an invalid nested default' do
-    it 'raises an error' do
-      expect do
-        Class.new(ActiveInteraction::Base) do
-          hash :a, default: { x: Object.new } do
-            hash :x
-          end
-        end
-      end.to raise_error ActiveInteraction::InvalidDefaultError
-    end
-  end
 end

--- a/spec/support/filters.rb
+++ b/spec/support/filters.rb
@@ -80,13 +80,15 @@ shared_examples_for 'a filter' do
   end
 
   describe '#clean' do
+    let(:result) { filter.clean(value, interaction) }
     let(:value) { nil }
+    let(:interaction) { nil }
 
     context 'optional' do
       include_context 'optional'
 
       it 'returns the default' do
-        expect(filter.clean(value)).to eql options[:default]
+        expect(result).to eql options[:default]
       end
     end
 
@@ -95,7 +97,7 @@ shared_examples_for 'a filter' do
 
       it 'raises an error' do
         expect do
-          filter.clean(value)
+          result
         end.to raise_error ActiveInteraction::MissingValueError
       end
 
@@ -104,7 +106,7 @@ shared_examples_for 'a filter' do
 
         it 'raises an error' do
           expect do
-            filter.clean(value)
+            result
           end.to raise_error ActiveInteraction::InvalidValueError
         end
       end
@@ -117,18 +119,21 @@ shared_examples_for 'a filter' do
 
       it 'raises an error' do
         expect do
-          filter.clean(value)
+          result
         end.to raise_error ActiveInteraction::InvalidDefaultError
       end
     end
   end
 
   describe '#default' do
+    let(:result) { filter.default(interaction) }
+    let(:interaction) { nil }
+
     context 'optional' do
       include_context 'optional'
 
       it 'returns the default' do
-        expect(filter.default).to eql options[:default]
+        expect(result).to eql options[:default]
       end
     end
 
@@ -137,7 +142,7 @@ shared_examples_for 'a filter' do
 
       it 'raises an error' do
         expect do
-          filter.default
+          result
         end.to raise_error ActiveInteraction::NoDefaultError
       end
     end
@@ -149,7 +154,7 @@ shared_examples_for 'a filter' do
 
       it 'raises an error' do
         expect do
-          filter.default
+          result
         end.to raise_error ActiveInteraction::InvalidDefaultError
       end
     end
@@ -163,7 +168,7 @@ shared_examples_for 'a filter' do
       end
 
       it 'returns the default' do
-        expect(filter.default).to eql options[:default].call
+        expect(result).to eql options[:default].call
       end
     end
   end


### PR DESCRIPTION
This pull request fixes #217. It's the most recent in a long line of attempts, including #241, #231, #222, and #221. 

This approach is reasonably clean so far. However I don't think it'll work out. There's one problem currently: Default lambdas inside hashes don't get evaluated in the context of the instance. 

``` rb
hash :h, default: {} do
  model :k, class: Object, default: -> { self }
end
# h: { k: nil }
```

Fixing that would require changing the arity of `cast`, which would end up touching a lot of files. I have some half-baked solutions in mind. I wanted to throw up this pull request for discussion, though. 