### PR TITLE
Allow nil for interfaces and models

### DIFF
--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -240,7 +240,7 @@ module ActiveInteraction
       self.class.filters.each do |name, filter|
         begin
           public_send("#{name}=", filter.clean(inputs[name]))
-        rescue InvalidValueError, MissingValueError, InvalidNestedValueError
+        rescue Error
           # #type_check will add errors if appropriate.
         end
       end

--- a/spec/active_interaction/concerns/active_recordable_spec.rb
+++ b/spec/active_interaction/concerns/active_recordable_spec.rb
@@ -2,14 +2,14 @@
 
 require 'spec_helper'
 
-InteractionWithFilter = Class.new(TestInteraction) do
+InteractionWithFloatFilter = Class.new(TestInteraction) do
   float :thing
 end
 
 describe ActiveInteraction::ActiveRecordable do
   include_context 'interactions'
 
-  let(:described_class) { InteractionWithFilter }
+  let(:described_class) { InteractionWithFloatFilter }
 
   describe '#column_for_attribute(name)' do
     let(:column) { outcome.column_for_attribute(name) }

--- a/spec/active_interaction/integration/interface_interaction_spec.rb
+++ b/spec/active_interaction/integration/interface_interaction_spec.rb
@@ -15,7 +15,7 @@ describe InterfaceInteraction do
     -> { [JSON, YAML].sample },
     methods: [:dump, :load]
 
-  it 'does not raise an error' do
+  it 'succeeds when given nil' do
     expect { result }.to_not raise_error
   end
 end

--- a/spec/active_interaction/integration/interface_interaction_spec.rb
+++ b/spec/active_interaction/integration/interface_interaction_spec.rb
@@ -4,9 +4,18 @@ require 'spec_helper'
 require 'json'
 require 'yaml'
 
-describe 'InterfaceInteraction' do
+InterfaceInteraction = Class.new(TestInteraction) do
+  interface :anything
+end
+
+describe InterfaceInteraction do
+  include_context 'interactions'
   it_behaves_like 'an interaction',
     :interface,
     -> { [JSON, YAML].sample },
     methods: [:dump, :load]
+
+  it 'does not raise an error' do
+    expect { result }.to_not raise_error
+  end
 end

--- a/spec/active_interaction/integration/model_interaction_spec.rb
+++ b/spec/active_interaction/integration/model_interaction_spec.rb
@@ -2,6 +2,15 @@
 
 require 'spec_helper'
 
-describe 'ModelInteraction' do
+ModelInteraction = Class.new(TestInteraction) do
+  model :object
+end
+
+describe ModelInteraction do
+  include_context 'interactions'
   it_behaves_like 'an interaction', :model, -> { // }, class: Regexp
+
+  it 'does not raise an error' do
+    expect { result }.to_not raise_error
+  end
 end

--- a/spec/active_interaction/integration/model_interaction_spec.rb
+++ b/spec/active_interaction/integration/model_interaction_spec.rb
@@ -10,7 +10,7 @@ describe ModelInteraction do
   include_context 'interactions'
   it_behaves_like 'an interaction', :model, -> { // }, class: Regexp
 
-  it 'does not raise an error' do
+  it 'succeeds when given nil' do
     expect { result }.to_not raise_error
   end
 end


### PR DESCRIPTION
Fixes #263. 

``` rb
class InterfaceInteraction < ActiveInteraction::Base
  interface :anything

  def execute
    anything
  end
end

InterfaceInteraction.run!(anything: nil)
# master
#   ActiveInteraction::NoDefaultError: anything
# gh-263
#   => nil

class ModelInteraction < ActiveInteraction::Base
  model :object

  def execute
    object
  end
end

ModelInteraction.run!(object: nil)
# master
#   ActiveInteraction::NoDefaultError: object
# gh-263
#   => nil
```