### PR TITLE
Don't eagerly evaluate proc defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changed
 
+- [#269][]: Prevented proc defaults from being eagerly evaluated.
 - [#264][]: Renamed `model` filter to `object`.
 
 # [1.5.0][] (2015-02-05)
@@ -510,3 +511,4 @@
   [#244]: https://github.com/orgsync/active_interaction/issues/244
   [#248]: https://github.com/orgsync/active_interaction/issues/248
   [#264]: https://github.com/orgsync/active_interaction/issues/264
+  [#269]: https://github.com/orgsync/active_interaction/issues/269

--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -147,6 +147,11 @@ module ActiveInteraction
         attr_accessor filter.name
         define_method("#{filter.name}?") { !public_send(filter.name).nil? }
 
+        eagerly_evaluate_default(filter)
+      end
+
+      # @param filter [Filter]
+      def eagerly_evaluate_default(filter)
         default = filter.options[:default]
         filter.default if default && !default.is_a?(Proc)
       end

--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -147,7 +147,8 @@ module ActiveInteraction
         attr_accessor filter.name
         define_method("#{filter.name}?") { !public_send(filter.name).nil? }
 
-        filter.default if filter.default?
+        default = filter.options[:default]
+        filter.default if default && !default.is_a?(Proc)
       end
     end
 

--- a/spec/active_interaction/integration/array_interaction_spec.rb
+++ b/spec/active_interaction/integration/array_interaction_spec.rb
@@ -39,6 +39,16 @@ describe ArrayInteraction do
     end
   end
 
+  context 'with an invalid default as a proc' do
+    it 'does not raise an error' do
+      expect do
+        Class.new(ActiveInteraction::Base) do
+          array :a, default: -> { Object.new }
+        end
+      end.to_not raise_error
+    end
+  end
+
   context 'with an invalid nested default' do
     it 'raises an error' do
       expect do

--- a/spec/active_interaction/integration/hash_interaction_spec.rb
+++ b/spec/active_interaction/integration/hash_interaction_spec.rb
@@ -39,6 +39,16 @@ describe HashInteraction do
     end
   end
 
+  context 'with an invalid default as a proc' do
+    it 'does not raise an error' do
+      expect do
+        Class.new(ActiveInteraction::Base) do
+          array :a, default: -> { Object.new }
+        end
+      end.to_not raise_error
+    end
+  end
+
   context 'with an invalid nested default' do
     it 'raises an error' do
       expect do


### PR DESCRIPTION
Fixes #269. 

This pull request makes it so that defaults don't get eagerly evaluated if they're procs. Take this interaction for example:

``` rb
class Example < ActiveInteraction::Base
  object :object,
    default: -> { puts 'default'; Object.new }
end
```

Simply by defining this class, `"default"` will be output the standard out. That's a little surprising.

We eagerly evaluate defaults to make sure you didn't give us something that would never work. Since procs can change every time they are called, it doesn't make sense to eagerly evaluate them for this purpose. 