### PR TITLE
Deprecate methods removed in v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## Added
+
+- Added `object` as an alias for `model`.
+- Added symbol support to `add`.
+- Added `details` as an alternative to `symbolic`.
+
+## Changed
+
+- Deprecated `model` in favor of `object`.
+- Deprecated `add_sym` in favor of `add`.
+- Deprecated `transaction`.
+- Deprecated `symbolic` in favor of `details`.
+
 # [1.5.1][] (2015-04-28)
 
 ## Fixed

--- a/lib/active_interaction.rb
+++ b/lib/active_interaction.rb
@@ -19,7 +19,7 @@ module ActiveInteraction
 
   def self.deprecate(klass, method, message = nil)
     options = { method => message }
-    options.merge(deprecator: DEPRECATOR) if DEPRECATOR
+    options.merge!(deprecator: DEPRECATOR) if DEPRECATOR
     klass.deprecate(options)
   end
 end

--- a/lib/active_interaction.rb
+++ b/lib/active_interaction.rb
@@ -11,7 +11,17 @@ require 'active_model'
 #
 # @version 1.5.0
 module ActiveInteraction
-  Deprecator = ::ActiveSupport::Deprecation.new('2', 'ActiveInteraction')
+  DEPRECATOR =
+    if ::ActiveSupport::Deprecation.respond_to?(:new)
+      ::ActiveSupport::Deprecation.new('2', 'ActiveInteraction')
+    end
+  private_constant :DEPRECATOR
+
+  def self.deprecate(klass, method, message = nil)
+    options = { method => message }
+    options.merge(deprecator: DEPRECATOR) if DEPRECATOR
+    klass.deprecate(options)
+  end
 end
 
 require 'active_interaction/version'

--- a/lib/active_interaction.rb
+++ b/lib/active_interaction.rb
@@ -2,6 +2,18 @@
 
 require 'active_model'
 
+# Manage application specific business logic.
+#
+# @author Aaron Lasseigne <aaron.lasseigne@gmail.com>
+# @author Taylor Fausak <taylor@fausak.me>
+#
+# @since 1.0.0
+#
+# @version 1.5.0
+module ActiveInteraction
+  Deprecator = ::ActiveSupport::Deprecation.new('2', 'ActiveInteraction')
+end
+
 require 'active_interaction/version'
 require 'active_interaction/errors'
 
@@ -43,13 +55,3 @@ require 'active_interaction/backports'
 
 I18n.load_path.unshift(*Dir[File.expand_path(
   File.join(%w[active_interaction locale *.yml]), File.dirname(__FILE__))])
-
-# Manage application specific business logic.
-#
-# @author Aaron Lasseigne <aaron.lasseigne@gmail.com>
-# @author Taylor Fausak <taylor@fausak.me>
-#
-# @since 1.0.0
-#
-# @version 1.5.0
-module ActiveInteraction end

--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -249,7 +249,7 @@ module ActiveInteraction
     def type_check
       run_callbacks(:type_check) do
         Validation.validate(self.class.filters, inputs).each do |error|
-          errors.add_sym(*error)
+          errors.add(*error)
         end
       end
     end

--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -121,6 +121,11 @@ module ActiveInteraction
         end
       end
 
+      def model(*)
+        super
+      end
+      deprecate model: 'use `object` instead', deprecator: Deprecator
+
       private
 
       # @param klass [Class]

--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -124,7 +124,7 @@ module ActiveInteraction
       def model(*)
         super
       end
-      deprecate model: 'use `object` instead', deprecator: Deprecator
+      ActiveInteraction.deprecate self, :model, 'use `object` instead'
 
       private
 

--- a/lib/active_interaction/concerns/transactable.rb
+++ b/lib/active_interaction/concerns/transactable.rb
@@ -57,7 +57,7 @@ module ActiveInteraction
 
         nil
       end
-      deprecate :transaction, deprecator: Deprecator
+      ActiveInteraction.deprecate self, :transaction
 
       # @return [Boolean]
       def transaction?

--- a/lib/active_interaction/concerns/transactable.rb
+++ b/lib/active_interaction/concerns/transactable.rb
@@ -41,7 +41,8 @@ module ActiveInteraction
     module ClassMethods # rubocop:disable Documentation
       # @param klass [Class]
       def inherited(klass)
-        klass.transaction(transaction?, transaction_options.dup)
+        klass.transaction_without_deprecation(
+          transaction?, transaction_options.dup)
 
         super
       end
@@ -56,6 +57,7 @@ module ActiveInteraction
 
         nil
       end
+      deprecate :transaction, deprecator: Deprecator
 
       # @return [Boolean]
       def transaction?

--- a/lib/active_interaction/errors.rb
+++ b/lib/active_interaction/errors.rb
@@ -99,9 +99,9 @@ module ActiveInteraction
     ActiveInteraction.deprecate self, :symbolic, 'use `details` instead'
 
     def details
-      @symbolic.each_with_object(Hash.new([])) do |(k, vs), h|
-        vs.each { |v| h[k] += [{ error: v }] }
-      end
+      h = Hash.new([]).with_indifferent_access
+      @symbolic.each { |k, vs| vs.each { |v| h[k] += [{ error: v }] } }
+      h
     end
 
     alias_method :add_without_details, :add

--- a/lib/active_interaction/errors.rb
+++ b/lib/active_interaction/errors.rb
@@ -127,7 +127,7 @@ module ActiveInteraction
 
       symbolic[attribute] += [symbol]
     end
-    deprecate add_sym: 'use `add` instead', deprecator: Deprecator
+    ActiveInteraction.deprecate self, :add_sym, 'use `add` instead'
 
     # @see ActiveModel::Errors#initialize
     #

--- a/lib/active_interaction/errors.rb
+++ b/lib/active_interaction/errors.rb
@@ -97,6 +97,14 @@ module ActiveInteraction
     # @return [Hash{Symbol => Array<Symbol>}]
     attr_reader :symbolic
 
+    alias_method :add_without_details, :add
+    def add_with_details(attribute, message = :invalid, options = {})
+      message = message.call if message.respond_to?(:call)
+      symbolic[attribute] += [message] if message.is_a?(Symbol)
+      add_without_details(attribute, message, options)
+    end
+    alias_method :add, :add_with_details
+
     # Adds a symbolic error message to an attribute.
     #
     # @example
@@ -119,6 +127,7 @@ module ActiveInteraction
 
       symbolic[attribute] += [symbol]
     end
+    deprecate add_sym: 'use `add` instead', deprecator: Deprecator
 
     # @see ActiveModel::Errors#initialize
     #

--- a/lib/active_interaction/errors.rb
+++ b/lib/active_interaction/errors.rb
@@ -123,7 +123,7 @@ module ActiveInteraction
     #
     # @see ActiveModel::Errors#add
     def add_sym(attribute, symbol = :invalid, message = nil, options = {})
-      add(attribute, message || symbol, options)
+      add_without_details(attribute, message || symbol, options)
 
       symbolic[attribute] += [symbol]
     end

--- a/lib/active_interaction/errors.rb
+++ b/lib/active_interaction/errors.rb
@@ -96,11 +96,16 @@ module ActiveInteraction
     #
     # @return [Hash{Symbol => Array<Symbol>}]
     attr_reader :symbolic
+    ActiveInteraction.deprecate self, :symbolic, 'use `details` instead'
+
+    def details
+      @symbolic
+    end
 
     alias_method :add_without_details, :add
     def add_with_details(attribute, message = :invalid, options = {})
       message = message.call if message.respond_to?(:call)
-      symbolic[attribute] += [message] if message.is_a?(Symbol)
+      details[attribute] += [message] if message.is_a?(Symbol)
       add_without_details(attribute, message, options)
     end
     alias_method :add, :add_with_details
@@ -109,7 +114,7 @@ module ActiveInteraction
     #
     # @example
     #   errors.add_sym(:attribute)
-    #   errors.symbolic
+    #   errors.details
     #   # => {:attribute=>[:invalid]}
     #   errors.messages
     #   # => {:attribute=>["is invalid"]}
@@ -125,7 +130,7 @@ module ActiveInteraction
     def add_sym(attribute, symbol = :invalid, message = nil, options = {})
       add_without_details(attribute, message || symbol, options)
 
-      symbolic[attribute] += [symbol]
+      details[attribute] += [symbol]
     end
     ActiveInteraction.deprecate self, :add_sym, 'use `add` instead'
 
@@ -142,7 +147,7 @@ module ActiveInteraction
     #
     # @private
     def initialize_dup(other)
-      @symbolic = other.symbolic.with_indifferent_access
+      @symbolic = other.details.with_indifferent_access
 
       super
     end
@@ -151,7 +156,7 @@ module ActiveInteraction
     #
     # @private
     def clear
-      symbolic.clear
+      details.clear
 
       super
     end
@@ -163,7 +168,7 @@ module ActiveInteraction
     # @return [Errors]
     def merge!(other)
       merge_messages!(other)
-      merge_symbolic!(other) if other.respond_to?(:symbolic)
+      merge_details!(other) if other.respond_to?(:details)
       self
     end
 
@@ -177,12 +182,12 @@ module ActiveInteraction
       end
     end
 
-    def merge_symbolic!(other)
-      other.symbolic.each do |attribute, symbols|
+    def merge_details!(other)
+      other.details.each do |attribute, symbols|
         symbols.each do |symbol|
-          next if symbolic[attribute].include?(symbol)
+          next if details[attribute].include?(symbol)
 
-          symbolic[attribute] += [symbol]
+          details[attribute] += [symbol]
         end
       end
     end

--- a/lib/active_interaction/filters/array_filter.rb
+++ b/lib/active_interaction/filters/array_filter.rb
@@ -54,6 +54,11 @@ module ActiveInteraction
       end
     end
 
+    def model(*)
+      super
+    end
+    ActiveInteraction.deprecate self, :model, 'use `object` instead'
+
     private
 
     # @return [Array<Class>]

--- a/lib/active_interaction/filters/hash_filter.rb
+++ b/lib/active_interaction/filters/hash_filter.rb
@@ -52,6 +52,11 @@ module ActiveInteraction
       end
     end
 
+    def model(*)
+      super
+    end
+    ActiveInteraction.deprecate self, :model, 'use `object` instead'
+
     private
 
     def clean_value(h, name, filter, value)

--- a/lib/active_interaction/filters/model_filter.rb
+++ b/lib/active_interaction/filters/model_filter.rb
@@ -19,6 +19,7 @@ module ActiveInteraction
   # @private
   class ModelFilter < Filter
     register :model
+    register :object
 
     def cast(value, reconstantize = true)
       @klass ||= klass

--- a/lib/active_interaction/locale/en.yml
+++ b/lib/active_interaction/locale/en.yml
@@ -18,6 +18,7 @@ en:
       integer: integer
       interface: interface
       model: model
+      object: object
       string: string
       symbol: symbol
       time: time

--- a/lib/active_interaction/modules/validation.rb
+++ b/lib/active_interaction/modules/validation.rb
@@ -25,10 +25,10 @@ module ActiveInteraction
       def error_args(filter, error)
         case error
         when InvalidNestedValueError
-          [filter.name, :invalid_nested, nil,
+          [filter.name, :invalid_nested,
            name: error.filter_name.inspect, value: error.input_value.inspect]
         when InvalidValueError
-          [filter.name, :invalid_type, nil, type: type(filter)]
+          [filter.name, :invalid_type, type: type(filter)]
         when MissingValueError
           [filter.name, :missing]
         end

--- a/spec/active_interaction/errors_spec.rb
+++ b/spec/active_interaction/errors_spec.rb
@@ -40,30 +40,30 @@ describe ActiveInteraction::Errors do
 
     context 'calling #add' do
       before do
-        allow(errors).to receive(:add)
+        allow(errors).to receive(:add_without_details)
       end
 
       it 'with the default' do
         errors.add_sym(:attribute)
-        expect(errors).to have_received(:add).once
+        expect(errors).to have_received(:add_without_details).once
           .with(:attribute, :invalid, {})
       end
 
       it 'with a symbol' do
         errors.add_sym(:attribute, :symbol)
-        expect(errors).to have_received(:add).once
+        expect(errors).to have_received(:add_without_details).once
           .with(:attribute, :symbol, {})
       end
 
       it 'with a symbol and message' do
         errors.add_sym(:attribute, :symbol, 'message')
-        expect(errors).to have_received(:add).once
+        expect(errors).to have_received(:add_without_details).once
           .with(:attribute, 'message', {})
       end
 
       it 'with a symbol, message and options' do
         errors.add_sym(:attribute, :symbol, 'message', key: :value)
-        expect(errors).to have_received(:add).once
+        expect(errors).to have_received(:add_without_details).once
           .with(:attribute, 'message', key: :value)
       end
     end

--- a/spec/active_interaction/modules/validation_spec.rb
+++ b/spec/active_interaction/modules/validation_spec.rb
@@ -42,7 +42,7 @@ describe ActiveInteraction::Validation do
           type = I18n.translate(
             "#{ActiveInteraction::Base.i18n_scope}.types.#{filter.class.slug}")
 
-          expect(result).to eql [[filter.name, :invalid_type, nil, type: type]]
+          expect(result).to eql [[filter.name, :invalid_type, type: type]]
         end
       end
 
@@ -65,7 +65,6 @@ describe ActiveInteraction::Validation do
           expect(result).to eql [[
             filter.name,
             :invalid_nested,
-            nil,
             { name: name.inspect, value: value.inspect }
           ]]
         end


### PR DESCRIPTION
Fixes #277. This pull request deprecates methods that will be removed in version 2.0.0. 

- `ActiveInteraction::Base.model` has been removed and replaced with `.object`. This deprecates the former and makes the latter available.
- `ActiveInteraction::Base.transaction` has been removed. This deprecates it.
- `ActiveInteraction::Errors#add_sym` has been removed and obsoleted by `#add`. This deprecates the former and updates the latter.

Here is an example of an interaction that uses all of the deprecated features:

``` rb
require 'active_interaction'

class Outdated < ActiveInteraction::Base
  model :anything, class: 'Object'

  transaction false

  def execute
    errors.add_sym(:base)
  end
end
Outdated.run
```

Running that with this pull request makes this output:

```
DEPRECATION WARNING: model is deprecated and will be removed from ActiveInteraction 2 (use `object` instead). (called from <class:Outdated> at tmp/example.rb:4)
DEPRECATION WARNING: transaction is deprecated and will be removed from ActiveInteraction 2. (called from <class:Outdated> at tmp/example.rb:6)
DEPRECATION WARNING: add_sym is deprecated and will be removed from ActiveInteraction 2 (use `add` instead). (called from execute at tmp/example.rb:9)
```

Although #277 does mention other changes, they are not things we can programmatically warn users about. People will have to read the change log to be aware of them. 