### PR TITLE
Don't monkey patch #transform_keys onto Hash

### DIFF
--- a/lib/active_interaction/backports.rb
+++ b/lib/active_interaction/backports.rb
@@ -17,16 +17,15 @@ module ActiveInteraction
     # Required for Rails < 3.2.13.
     protected :initialize_dup
   end
-end
 
-# @private
-class Hash
-  # Required for Rails < 4.0.0.
-  def transform_keys
-    result = {}
-    each_key do |key|
-      result[yield(key)] = self[key]
+  class HashFilter # rubocop:disable Style/Documentation
+    # Required for Rails < 4.0.0.
+    def self.transform_keys(hash, &block)
+      return hash.transform_keys(&block) if hash.respond_to?(:transform_keys)
+
+      result = {}
+      hash.each_key { |key| result[block.call(key)] = hash[key] }
+      result
     end
-    result
-  end unless method_defined?(:transform_keys)
+  end
 end

--- a/lib/active_interaction/filters/hash_filter.rb
+++ b/lib/active_interaction/filters/hash_filter.rb
@@ -76,7 +76,7 @@ module ActiveInteraction
     end
 
     def stringify_the_symbol_keys(hash)
-      hash.transform_keys { |key| key.is_a?(Symbol) ? key.to_s : key }
+      self.class.transform_keys(hash) { |k| k.is_a?(Symbol) ? k.to_s : k }
     end
   end
 end


### PR DESCRIPTION
I think we should not monkey patch classes outside of the ActiveInteraction module. This pull request removes the `Hash#transform_keys` monkey patch. It replaces it with a class method that delegates to `#transform_keys` if it is available. If it's not, it implements its own version. 