### PR TITLE
Conditionally include active_record

### DIFF
--- a/lib/active_interaction/concerns/transactable.rb
+++ b/lib/active_interaction/concerns/transactable.rb
@@ -1,8 +1,6 @@
 # coding: utf-8
 
-begin
-  require 'active_record'
-rescue LoadError
+if defined?(::Mongoid)
   module ActiveRecord # rubocop:disable Style/Documentation
     Rollback = Class.new(ActiveInteraction::Error)
 
@@ -13,7 +11,13 @@ rescue LoadError
       end
     end
   end
+else
+  begin
+    require 'active_record'
+  rescue LoadError
+  end
 end
+
 
 module ActiveInteraction
   # @private

--- a/lib/active_interaction/filters/array_filter.rb
+++ b/lib/active_interaction/filters/array_filter.rb
@@ -1,8 +1,10 @@
 # coding: utf-8
 
-begin
-  require 'active_record'
-rescue LoadError
+if !defined?(::Mongoid)
+  begin
+    require 'active_record'
+  rescue LoadError
+  end
 end
 
 module ActiveInteraction
@@ -65,7 +67,7 @@ module ActiveInteraction
     def classes
       result = [Array]
 
-      if ActiveRecord.const_defined?(:Relation)
+      if !defined?(::Mongoid) and ActiveRecord.const_defined?(:Relation)
         result.push(ActiveRecord::Relation)
       end
 


### PR DESCRIPTION
I love this gem, but I use mongoid and the require 'active_record' give me 
```
Failure/Error: Unable to find matching line from backtrace
     ActiveRecord::ConnectionNotEstablished:
       No connection pool for ActiveRecord::Base
```
when I try to run some spec with rspec.
I tried to fix this, requiring conditionally active_record like in the ransack gem https://github.com/activerecord-hackery/ransack/blob/master/lib/ransack.rb. I don't known if it is the right way.
Bye!