### PR TITLE
Check for rewind instead of eof? on file inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Changed
+## Fixed
 
 - [#286][]: Change `file` filter to check for `rewind` instead of `eof?`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Changed
+
+- [#286][]: Change `file` filter to check for `rewind` instead of `eof?`.
+
 # [2.0.0][] (2015-05-06)
 
 For help upgrading to version 2, please read [the announcement post][].
@@ -546,5 +550,6 @@ For help upgrading to version 2, please read [the announcement post][].
   [#264]: https://github.com/orgsync/active_interaction/issues/264
   [#265]: https://github.com/orgsync/active_interaction/issues/265
   [#269]: https://github.com/orgsync/active_interaction/issues/269
+  [#286]: https://github.com/orgsync/active_interaction/issues/286
 
   [the announcement post]: http://devblog.orgsync.com/2015/05/06/announcing-active-interaction-2/

--- a/active_interaction.gemspec
+++ b/active_interaction.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'activemodel', '>= 3.2', '<5'
 
   {
+    'actionpack' => ['>= 3.2', '< 5'],
     'bundler' => ['~> 1.9'],
     'coveralls' => ['~> 0.8'],
     'guard-rspec' => ['~> 4.5'],

--- a/active_interaction.gemspec
+++ b/active_interaction.gemspec
@@ -34,17 +34,17 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'activemodel', '>= 3.2', '<5'
 
   {
-    'bundler' => '~> 1.9',
-    'coveralls' => '~> 0.8',
-    'guard-rspec' => '~> 4.5',
-    'guard-rubocop' => '~> 1.2',
-    'kramdown' => '~> 1.7',
-    'rake' => '~> 10.4',
-    'rspec' => '~> 3.2',
-    'rubocop' => '~> 0.30',
-    'yard' => '~> 0.8'
-  }.each do |name, version|
-    gem.add_development_dependency name, version
+    'bundler' => ['~> 1.9'],
+    'coveralls' => ['~> 0.8'],
+    'guard-rspec' => ['~> 4.5'],
+    'guard-rubocop' => ['~> 1.2'],
+    'kramdown' => ['~> 1.7'],
+    'rake' => ['~> 10.4'],
+    'rspec' => ['~> 3.2'],
+    'rubocop' => ['~> 0.30'],
+    'yard' => ['~> 0.8']
+  }.each do |name, versions|
+    gem.add_development_dependency name, *versions
   end
 
   if RUBY_ENGINE == 'rbx'

--- a/lib/active_interaction/filters/file_filter.rb
+++ b/lib/active_interaction/filters/file_filter.rb
@@ -4,8 +4,9 @@ module ActiveInteraction
   class Base
     # @!method self.file(*attributes, options = {})
     #   Creates accessors for the attributes and ensures that values passed to
-    #   the attributes respond to the `eof?` method. This is useful when passing
-    #   in Rails params that include a file upload or another generic IO object.
+    #   the attributes respond to the `rewind` method. This is useful when
+    #   passing in Rails params that include a file upload or another generic
+    #   IO object.
     #
     #   @!macro filter_method_params
     #
@@ -24,7 +25,7 @@ module ActiveInteraction
     private
 
     def methods
-      [:eof?]
+      [:rewind]
     end
   end
 end

--- a/spec/active_interaction/filters/file_filter_spec.rb
+++ b/spec/active_interaction/filters/file_filter_spec.rb
@@ -25,8 +25,8 @@ describe ActiveInteraction::FileFilter, :filter do
       end
     end
 
-    context 'with an object that responds to #eof?' do
-      let(:value) { double(eof?: true) }
+    context 'with an object that responds to #rewind' do
+      let(:value) { double(rewind: nil) }
 
       it 'returns the object' do
         expect(result).to eq value

--- a/spec/active_interaction/integration/file_interaction_spec.rb
+++ b/spec/active_interaction/integration/file_interaction_spec.rb
@@ -1,7 +1,20 @@
 # coding: utf-8
 
 require 'spec_helper'
+require 'action_dispatch'
 
-describe 'FileInteraction' do
+FileInteraction = Class.new(TestInteraction) do
+  file :a
+end
+
+describe FileInteraction do
+  include_context 'interactions'
   it_behaves_like 'an interaction', :file, -> { File.open(__FILE__) }
+
+  it 'works with an uploaded file' do
+    file = File.open(__FILE__)
+    uploaded_file = ActionDispatch::Http::UploadedFile.new(tempfile: file)
+    inputs[:a] = uploaded_file
+    expect(outcome).to be_valid
+  end
 end


### PR DESCRIPTION
Fixes #286. 

This pull request changes the method we check for on file inputs from `#eof?` to `#rewind`. The former is not available on uploaded files in Rails until version 4.0.2. I would prefer to use something more intention-revealing like `#to_io`, but that's not available until version 4.2. Since we support 3.2.0, we have to pick from the method available in that version. 

I also added a test case to make sure we don't accidentally break this again. 