### PR TITLE
Test against activemodel 3.2.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,9 @@ AllCops:
   - example/db/schema.rb
   - tmp/**/*
   - vendor/**/*
+FileName:
+  Exclude:
+  - gemfiles/*
 HandleExceptions:
   Enabled: false
 MultilineOperationIndentation:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
   - env: RAKE_TASK=rubocop
     rvm: 2.2
-  - gemfile: gemfiles/activemodel3.rb
+  - gemfile: gemfiles/activemodel-3.2.rb
     rvm: 2.2
 notifications:
   email: false

--- a/gemfiles/activemodel-3.2.rb
+++ b/gemfiles/activemodel-3.2.rb
@@ -4,4 +4,4 @@ source 'https://rubygems.org'
 
 gemspec path: '..'
 
-gem 'activemodel', '~> 3.0'
+gem 'activemodel', '3.2'


### PR DESCRIPTION
While working on #287, I realized that we are testing against the latest ActiveModel 3.2.x. Since we support 3.2.0, we should test against it instead.