### PR TITLE
Remove obsolete deprecate method

### DIFF
--- a/lib/active_interaction.rb
+++ b/lib/active_interaction.rb
@@ -11,17 +11,6 @@ require 'active_model'
 #
 # @version 2.0.0
 module ActiveInteraction
-  DEPRECATOR =
-    if ::ActiveSupport::Deprecation.respond_to?(:new)
-      ::ActiveSupport::Deprecation.new('2', 'ActiveInteraction')
-    end
-  private_constant :DEPRECATOR
-
-  def self.deprecate(klass, method, message = nil)
-    options = { method => message }
-    options.merge!(deprecator: DEPRECATOR) if DEPRECATOR
-    klass.deprecate(options)
-  end
 end
 
 require 'active_interaction/version'

--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -99,11 +99,6 @@ module ActiveInteraction
         end
       end
 
-      def model(*)
-        super
-      end
-      ActiveInteraction.deprecate self, :model, 'use `object` instead'
-
       private
 
       # @param klass [Class]

--- a/lib/active_interaction/filters/array_filter.rb
+++ b/lib/active_interaction/filters/array_filter.rb
@@ -54,11 +54,6 @@ module ActiveInteraction
       end
     end
 
-    def model(*)
-      super
-    end
-    ActiveInteraction.deprecate self, :model, 'use `object` instead'
-
     private
 
     # @return [Array<Class>]

--- a/lib/active_interaction/filters/hash_filter.rb
+++ b/lib/active_interaction/filters/hash_filter.rb
@@ -49,11 +49,6 @@ module ActiveInteraction
       end
     end
 
-    def model(*)
-      super
-    end
-    ActiveInteraction.deprecate self, :model, 'use `object` instead'
-
     private
 
     def clean_value(h, name, filter, value)


### PR DESCRIPTION
This should have been removed in 2.0.0.