### PR TITLE
Add method to check for optional inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1167,9 +1167,9 @@ input type.
 ### Optional inputs
 
 Optional inputs can be defined by using the `:default` option as described in
-[the Filters section][#filters]. Within the interaction, provided and default
-values are merged to create `inputs`. There are times where it is useful to
-know whether a value was passed to `run` or the result of a filter default. In
+[the Filters section][]. Within the interaction, provided and default values
+are merged to create `inputs`. There are times where it is useful to know
+whether a value was passed to `run` or the result of a filter default. In
 particular, it is useful when `nil` is an acceptable value. For example, you
 may optionally track your users' birthdays. You can use the `given?` predicate
 to see if an input was even passed to `run`.
@@ -1307,5 +1307,4 @@ Logo design by [Tyler Lee][].
 [formtastic]: https://rubygems.org/gems/formtastic
 [simple_form]: https://rubygems.org/gems/simple_form
 [the filters section]: #filters
-[the predicates section]: #predicates
 [tyler lee]: https://github.com/tylerlee

--- a/README.md
+++ b/README.md
@@ -1171,7 +1171,7 @@ Optional inputs can be defined by using the `:default` option as described in
 values are merged to create `inputs`. There are times where it is useful to
 know whether a value was passed to `run` or the result of a filter default. In
 particular, it is useful when `nil` is an acceptable value. For example, you
-may optionally track your users' birthdays. You can use the `given?`` predicate
+may optionally track your users' birthdays. You can use the `given?` predicate
 to see if an input was even passed to `run`.
 
 ``` rb

--- a/README.md
+++ b/README.md
@@ -1166,11 +1166,13 @@ input type.
 
 ### Optional inputs
 
-[The filters section][] shows you how to define optional inputs with the
-`default` option. For inputs with a default, [the predicates section][] shows
-you how to test for `nil`. What if you have an optional input where `nil` is a
-valid value? For example, you may optionally track your users' birthdays. You
-can use the `given?` predicate to see if an input was even passed to `run`.
+Optional inputs can be defined by using the `:default` option as described in
+[the Filters section][#filters]. Within the interaction, provided and default
+values are merged to create `inputs`. There are times where it is useful to
+know whether a value was passed to `run` or the result of a filter default. In
+particular, it is useful when `nil` is an acceptable value. For example, you
+may optionally track your users' birthdays. You can use the `given?`` predicate
+to see if an input was even passed to `run`.
 
 ``` rb
 class UpdateUser < ActiveInteraction::Base

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Read more on [the project page][] or check out [the full documentation][].
   - [Descriptions](#descriptions)
   - [Errors](#errors)
   - [Forms](#forms)
+  - [Optional inputs](#optional-inputs)
   - [Predicates](#predicates)
   - [Translations](#translations)
 - [Credits](#credits)
@@ -1163,6 +1164,42 @@ used to define the inputs on your interaction will relay type information to
 these gems. As a result, form fields will automatically use the appropriate
 input type.
 
+### Optional inputs
+
+[The filters section][] shows you how to define optional inputs with the
+`default` option. For inputs with a default, [the predicates section][] shows
+you how to test for `nil`. What if you have an optional input where `nil` is a
+valid value? For example, you may optionally track your users' birthdays. You
+can use the `given?` predicate to see if an input was even passed to `run`.
+
+``` rb
+class UpdateUser < ActiveInteraction::Base
+  object :user
+  date :birthday,
+    default: nil
+
+  def execute
+    user.birthday = birthday if given?(:birthday)
+    errors.merge!(user) unless user.save
+    user
+  end
+end
+```
+
+Now you have a few options. If you don't want to update their birthday, leave
+it out of the hash. If you want to remove their birthday, set `birthday: nil`.
+And if you want to update it, pass in the new value as usual.
+
+``` rb
+user = User.find(...)
+# Don't update their birthday.
+UpdateUser.run!(user: user)
+# Remove their birthday.
+UpdateUser.run!(user: user, birthday: nil)
+# Update their birthday.
+UpdateUser.run!(user: user, birthday: Date.new(2000, 1, 2))
+```
+
 ### Predicates
 
 ActiveInteraction creates a predicate method for every input defined by a filter. So if you have an input called `foo`, there will be a predicate method called `#foo?`. That method will tell you if the input was given (that is, if it was not `nil`).
@@ -1267,4 +1304,6 @@ Logo design by [Tyler Lee][].
 [the mit license]: LICENSE.md
 [formtastic]: https://rubygems.org/gems/formtastic
 [simple_form]: https://rubygems.org/gems/simple_form
+[the filters section]: #filters
+[the predicates section]: #predicates
 [tyler lee]: https://github.com/tylerlee

--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -197,11 +197,24 @@ module ActiveInteraction
       end
     end
 
-    # TODO
+    # Returns `true` if the given key was in the hash passed to {.run}.
+    # Otherwise returns `false`. Use this to figure out if an input was given,
+    # even if it was `nil`.
+    #
+    # @example
+    #   class Example < ActiveInteraction::Base
+    #     integer :x, default: nil
+    #     def execute; given?(:x) end
+    #   end
+    #   Example.run!()        # => false
+    #   Example.run!(x: nil)  # => true
+    #   Example.run!(x: rand) # => true
     #
     # @param input [#to_sym]
     #
     # @return [Boolean]
+    #
+    # @since 2.1.0
     def given?(input)
       @_interaction_keys.include?(input.to_sym)
     end

--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -164,9 +164,7 @@ module ActiveInteraction
     def initialize(inputs = {})
       fail ArgumentError, 'inputs must be a hash' unless inputs.is_a?(Hash)
 
-      symbolized_inputs = inputs.symbolize_keys
-      @_interaction_keys = symbolized_inputs.keys.to_set
-      process_inputs(symbolized_inputs)
+      process_inputs(inputs.symbolize_keys)
     end
 
     # @!method compose(other, inputs = {})
@@ -231,6 +229,8 @@ module ActiveInteraction
 
     # @param inputs [Hash{Symbol => Object}]
     def process_inputs(inputs)
+      @_interaction_keys = inputs.keys.to_set & self.class.filters.keys
+
       inputs.each do |key, value|
         fail InvalidValueError, key.inspect if InputProcessor.reserved?(key)
 

--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 require 'active_support/core_ext/hash/indifferent_access'
+require 'set'
 
 module ActiveInteraction
   # @abstract Subclass and override {#execute} to implement a custom
@@ -163,7 +164,9 @@ module ActiveInteraction
     def initialize(inputs = {})
       fail ArgumentError, 'inputs must be a hash' unless inputs.is_a?(Hash)
 
-      process_inputs(inputs.symbolize_keys)
+      symbolized_inputs = inputs.symbolize_keys
+      @_interaction_keys = symbolized_inputs.keys.to_set
+      process_inputs(symbolized_inputs)
     end
 
     # @!method compose(other, inputs = {})
@@ -192,6 +195,15 @@ module ActiveInteraction
       self.class.filters.keys.each_with_object({}) do |name, h|
         h[name] = public_send(name)
       end
+    end
+
+    # TODO
+    #
+    # @param input [#to_sym]
+    #
+    # @return [Boolean]
+    def given?(input)
+      @_interaction_keys.include?(input.to_sym)
     end
 
     protected

--- a/spec/active_interaction/base_spec.rb
+++ b/spec/active_interaction/base_spec.rb
@@ -365,6 +365,28 @@ describe ActiveInteraction::Base do
     end
   end
 
+  describe '#given?' do
+    let(:described_class) do
+      Class.new(TestInteraction) do
+        float :x,
+          default: nil
+
+        def execute
+          given?(:x)
+        end
+      end
+    end
+
+    it do
+      expect(result).to be_falsey
+    end
+
+    it do
+      inputs[:x] = nil
+      expect(result).to be_truthy
+    end
+  end
+
   context 'inheritance' do
     context 'filters' do
       let(:described_class) { InteractionWithFilter }

--- a/spec/active_interaction/base_spec.rb
+++ b/spec/active_interaction/base_spec.rb
@@ -377,13 +377,29 @@ describe ActiveInteraction::Base do
       end
     end
 
-    it do
-      expect(result).to be_falsey
+    it 'is false when the input is not given' do
+      expect(result).to be false
     end
 
-    it do
+    it 'is true when the input is nil' do
       inputs[:x] = nil
-      expect(result).to be_truthy
+      expect(result).to be true
+    end
+
+    it 'is true when the input is given' do
+      inputs[:x] = rand
+      expect(result).to be true
+    end
+
+    it 'symbolizes its argument' do
+      described_class.class_exec do
+        def execute
+          given?('x')
+        end
+      end
+
+      inputs[:x] = rand
+      expect(result).to be true
     end
   end
 

--- a/spec/active_interaction/base_spec.rb
+++ b/spec/active_interaction/base_spec.rb
@@ -401,6 +401,17 @@ describe ActiveInteraction::Base do
       inputs[:x] = rand
       expect(result).to be true
     end
+
+    it 'only tracks inputs with filters' do
+      described_class.class_exec do
+        def execute
+          given?(:y)
+        end
+      end
+
+      inputs[:y] = rand
+      expect(result).to be false
+    end
   end
 
   context 'inheritance' do


### PR DESCRIPTION
Fixes #294. This pull request adds a new `#given?` method to interactions that checks for optional inputs. It allows users to check for the difference between an input being given as `nil` and an input not being given at all. For example:

``` rb
class Example < ActiveInteraction::Base
  integer :x, :y,
    default: nil

  def execute
    [given?(:x), given?(:y)]
  end
end

Example.run!(y: nil)
# => [false, true]
```

Still to do:

- [x] Finish writing documentation.
- [x] Finish writing tests.