### PR TITLE
Raise InvalidDefaultError instead of silently converting to nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Fixed
+
+- [#296][]: Fixed a bug that silently converted invalid lazy default values to
+  `nil` instead of raising an `InvalidDefaultError`.
+
 # [2.1.0][] (2015-07-30)
 
 ## Added
@@ -565,5 +570,6 @@ For help upgrading to version 2, please read [the announcement post][].
   [#286]: https://github.com/orgsync/active_interaction/issues/286
   [#289]: https://github.com/orgsync/active_interaction/issues/289
   [#295]: https://github.com/orgsync/active_interaction/issues/295
+  [#296]: https://github.com/orgsync/active_interaction/issues/296
 
   [the announcement post]: http://devblog.orgsync.com/2015/05/06/announcing-active-interaction-2/

--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -248,7 +248,7 @@ module ActiveInteraction
       self.class.filters.each do |name, filter|
         begin
           public_send("#{name}=", filter.clean(inputs[name]))
-        rescue Error
+        rescue InvalidValueError, MissingValueError, NoDefaultError
           # #type_check will add errors if appropriate.
         end
       end

--- a/spec/support/interactions.rb
+++ b/spec/support/interactions.rb
@@ -30,6 +30,19 @@ shared_examples_for 'an interaction' do |type, generator, filter_options = {}|
     end
   end
 
+  context 'with an invalid lazy default' do
+    let(:described_class) do
+      Class.new(TestInteraction) do
+        public_send(type, :default,
+          filter_options.merge(default: -> { Object.new }))
+      end
+    end
+
+    it 'raises an error' do
+      expect { outcome }.to raise_error ActiveInteraction::InvalidDefaultError
+    end
+  end
+
   context 'without required inputs' do
     it 'is invalid' do
       expect(outcome).to be_invalid


### PR DESCRIPTION
This pull request fixes #296. It more or less reverts part of e52dd8b1b6386e89665830a65d1e8a267155411c that proved unnecessary (and in fact harmful) after e50bc2bac3f52fbe4d4224ada085497fa606cd01. 

Can you review this, @AaronLasseigne? 