### PR TITLE
Fix #298; don't raise exceptions for invalid nested values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Fixed
+
+- [#298][]: Fixed a bug that raised exceptions when passing invalid nested
+  values.
+
 # [2.1.1][] (2015-08-04)
 
 ## Fixed
@@ -574,5 +579,6 @@ For help upgrading to version 2, please read [the announcement post][].
   [#289]: https://github.com/orgsync/active_interaction/issues/289
   [#295]: https://github.com/orgsync/active_interaction/issues/295
   [#296]: https://github.com/orgsync/active_interaction/issues/296
+  [#298]: https://github.com/orgsync/active_interaction/issues/298
 
   [the announcement post]: http://devblog.orgsync.com/2015/05/06/announcing-active-interaction-2/

--- a/lib/active_interaction/errors.rb
+++ b/lib/active_interaction/errors.rb
@@ -57,7 +57,7 @@ module ActiveInteraction
   # Raised if a user-supplied value to a nested hash input is invalid.
   #
   # @return [Class]
-  class InvalidNestedValueError < Error
+  class InvalidNestedValueError < InvalidValueError
     # @return [Symbol]
     attr_reader :filter_name
 

--- a/spec/active_interaction/integration/array_interaction_spec.rb
+++ b/spec/active_interaction/integration/array_interaction_spec.rb
@@ -27,6 +27,11 @@ describe ArrayInteraction do
     it 'returns the correct value for :b' do
       expect(result[:b]).to eql [[]]
     end
+
+    it 'does not raise an error with an invalid nested value' do
+      inputs[:a] = [false]
+      expect { outcome }.to_not raise_error
+    end
   end
 
   context 'with an invalid default' do

--- a/spec/active_interaction/integration/hash_interaction_spec.rb
+++ b/spec/active_interaction/integration/hash_interaction_spec.rb
@@ -27,6 +27,11 @@ describe HashInteraction do
     it 'returns the correct value for :b' do
       expect(result[:b]).to eql('x' => {})
     end
+
+    it 'does not raise an error with an invalid nested value' do
+      inputs[:a] = { x: false }
+      expect { outcome }.to_not raise_error
+    end
   end
 
   context 'with an invalid default' do


### PR DESCRIPTION
This pull request fixes #298. It makes `InvalidNestedValueError` a subclass of `InvalidValueError`. This seemed like the best way to fix the issue. I can't imagine there are any situations where you'd want to catch an invalid value error but ignore invalid nested value errors.

@AaronLasseigne can you review this? 