### PR TITLE
Improve error message for invalid classes

### DIFF
--- a/lib/active_interaction/filters/object_filter.rb
+++ b/lib/active_interaction/filters/object_filter.rb
@@ -42,7 +42,7 @@ module ActiveInteraction
       klass_name = options.fetch(:class, name).to_s.camelize
       Object.const_get(klass_name)
     rescue NameError
-      raise InvalidClassError, klass_name.inspect
+      raise InvalidClassError, "class #{klass_name.inspect} does not exist"
     end
 
     # @param value [Object]


### PR DESCRIPTION
This pull request is in response to #302. It changes the `InvalidClassError` message. If you define an object filter for a class that doesn't exist, the message can be confusing. 

``` rb
class Example < ActiveInteraction::Base
  object :cow
end
Example.run
# ActiveInteraction::InvalidClassError: "Cow"
```

The class is invalid to ActiveInteraction because it doesn't exist. The new error message is hopefully better.

``` rb
Example.run
# ActiveInteraction::InvalidClassError: class "Cow" does not exist
```