### PR TITLE
Warn when redefining a filter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,8 @@ AllCops:
   - example/db/schema.rb
   - tmp/**/*
   - vendor/**/*
+ClassLength:
+  Max: 120
 Documentation:
   Exclude:
   - spec/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Added
+
+- [#310][]: Added a warning when a filter is redefined.
+
 # [2.1.3][] (2015-10-02)
 
 ## Fixed
@@ -604,5 +608,6 @@ For help upgrading to version 2, please read [the announcement post][].
   [#298]: https://github.com/orgsync/active_interaction/issues/298
   [#303]: https://github.com/orgsync/active_interaction/issues/303
   [#304]: https://github.com/orgsync/active_interaction/issues/304
+  [#310]: https://github.com/orgsync/active_interaction/issues/310
 
   [the announcement post]: http://devblog.orgsync.com/2015/05/06/announcing-active-interaction-2/

--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -143,10 +143,14 @@ module ActiveInteraction
 
       # @param filter [Filter]
       def initialize_filter(filter)
-        filters[filter.name] = filter
+        attribute = filter.name
+        if filters.key?(attribute)
+          warn "WARNING: Redefining #{name}##{attribute} filter!"
+        end
+        filters[attribute] = filter
 
-        attr_accessor filter.name
-        define_method("#{filter.name}?") { !public_send(filter.name).nil? }
+        attr_accessor attribute
+        define_method("#{attribute}?") { !public_send(attribute).nil? }
 
         eagerly_evaluate_default(filter)
       end

--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -145,7 +145,7 @@ module ActiveInteraction
       def initialize_filter(filter)
         attribute = filter.name
         if filters.key?(attribute)
-          warn "WARNING: Redefining #{name}##{attribute} filter!"
+          warn "WARNING: Redefining #{name}##{attribute} filter"
         end
         filters[attribute] = filter
 

--- a/spec/active_interaction/base_spec.rb
+++ b/spec/active_interaction/base_spec.rb
@@ -226,6 +226,12 @@ describe ActiveInteraction::Base do
     let(:described_class) { InteractionWithFilter }
     let(:thing) { rand }
 
+    it 'warns when redefining a filter' do
+      klass = Class.new(described_class)
+      expect(klass).to receive(:warn).with(/\AWARNING:/)
+      klass.boolean :thing
+    end
+
     describe '.run(inputs = {})' do
       it "returns an instance of #{described_class}" do
         expect(outcome).to be_a described_class


### PR DESCRIPTION
This pull request makes it so that you get a warning when you redefine a filter. Issue #308 brought the need for this to my attention. 

Here is an example of the warning:

``` rb
class Example < ActiveInteraction::Base
  boolean :x, :x
end
# WARNING: Redefining Example#x filter!
```