### PR TITLE
Give better error message for invalid nested defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Changed
+
+- [#311][]: Changed the error message when defining the default value for a
+  hash.
+
 # [2.1.3][] (2015-10-02)
 
 ## Fixed

--- a/lib/active_interaction/filter.rb
+++ b/lib/active_interaction/filter.rb
@@ -127,6 +127,8 @@ module ActiveInteraction
       fail InvalidValueError if value.is_a?(GroupedInput)
 
       cast(value)
+    rescue InvalidNestedValueError => error
+      raise InvalidDefaultError, "#{name}: #{value.inspect} (#{error})"
     rescue InvalidValueError, MissingValueError
       raise InvalidDefaultError, "#{name}: #{value.inspect}"
     end

--- a/spec/active_interaction/integration/hash_interaction_spec.rb
+++ b/spec/active_interaction/integration/hash_interaction_spec.rb
@@ -55,10 +55,20 @@ describe HashInteraction do
   end
 
   context 'with an invalid nested default' do
-    it 'raises an error' do
+    it 'raises an error with a non-empty hash' do
       expect do
         Class.new(ActiveInteraction::Base) do
           hash :a, default: { x: Object.new } do
+            hash :x
+          end
+        end
+      end.to raise_error ActiveInteraction::InvalidDefaultError
+    end
+
+    it 'raises an error' do
+      expect do
+        Class.new(ActiveInteraction::Base) do
+          hash :a, default: {} do
             hash :x
           end
         end


### PR DESCRIPTION
This pull request changes the error message when you have an invalid nested default. Its goal is to make it clearer what the problem is. Issue #309 may have been avoided if something like this was in place. 

Here is an example of the new message:

``` rb
class Example < ActiveInteraction::Base
  hash :h,
    default: {} do
      boolean :b
    end
end
# ActiveInteraction::InvalidDefaultError: h: {} (b: nil)
```