### PR TITLE
Don't require Active Record

### DIFF
--- a/lib/active_interaction/filters/array_filter.rb
+++ b/lib/active_interaction/filters/array_filter.rb
@@ -1,10 +1,5 @@
 # coding: utf-8
 
-begin
-  require 'active_record'
-rescue LoadError
-end
-
 module ActiveInteraction
   class Base
     # @!method self.array(*attributes, options = {}, &block)


### PR DESCRIPTION
This pull request fixes #320. It avoids requiring ActiveRecord. This is necessary because other gems use the existence of ActiveRecord to do other things. In #320, for example, rspec-rails tries to use the not-configured database because it thinks we're using ActiveRecord.

I think this is a safe change to make because we only refer to ActiveRecord at runtime in `ActiveInteraction::ArrayFilter#classes`. If you want to pass an ActiveRecord collection to an array filter, obviously you have already loaded ActiveRecord. 