### PR TITLE
switch internal only error to a throw/catch

### DIFF
--- a/lib/active_interaction/errors.rb
+++ b/lib/active_interaction/errors.rb
@@ -74,21 +74,6 @@ module ActiveInteraction
     end
   end
 
-  # Used by {Runnable} to signal a failure when composing.
-  #
-  # @private
-  class Interrupt < Error
-    attr_reader :outcome
-
-    # @param outcome [Runnable]
-    def initialize(outcome)
-      super()
-
-      @outcome = outcome
-    end
-  end
-  private_constant :Interrupt
-
   # An extension that provides the ability to merge other errors into itself.
   class Errors < ActiveModel::Errors
     # Merge other errors into this one.


### PR DESCRIPTION
There's no need for a full on error object here. Ruby has throw/catch to handle this and it help distinguish errors that might reach the end user from what is otherwise an internal signal.