### PR TITLE
JRuby 9000

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,6 @@ rvm:
 - 2.2
 - 2.1
 - 2.0
-- jruby
+- jruby-9
 - rbx-2
 script: bundle exec rake $RAKE_TASK


### PR DESCRIPTION
This pull request tries to configure Travis CI to use JRuby 9000 instead of JRuby 1.7. See #344 for details.