### PR TITLE
Do not translate error strings on :base when merging errors.

### DIFF
--- a/lib/active_interaction/errors.rb
+++ b/lib/active_interaction/errors.rb
@@ -121,8 +121,8 @@ module ActiveInteraction
       if attribute?(attribute)
         add(attribute, error, detail) unless added?(attribute, error, detail)
       else
-        message = full_message(
-          attribute, other.generate_message(attribute, error))
+        translated_error = translate(other, attribute, error)
+        message = full_message(attribute, translated_error)
         attribute = :base
         add(attribute, message) unless added?(attribute, message)
       end
@@ -130,6 +130,14 @@ module ActiveInteraction
 
     def attribute?(attribute)
       @base.respond_to?(attribute)
+    end
+
+    def translate(other, attribute, error)
+      if error.is_a?(Symbol)
+        other.generate_message(attribute, error)
+      else
+        error
+      end
     end
   end
 end

--- a/spec/active_interaction/errors_spec.rb
+++ b/spec/active_interaction/errors_spec.rb
@@ -57,13 +57,28 @@ describe ActiveInteraction::Errors do
     end
 
     context 'with a detailed error' do
-      before do
-        other.add(:attribute)
+      context 'that is a symbol' do
+        before do
+          other.add(:attribute)
+        end
+
+        it 'adds the error' do
+          errors.merge!(other)
+          expect(errors.details[:attribute]).to eql [{ error: :invalid }]
+        end
       end
 
-      it 'adds the error' do
-        errors.merge!(other)
-        expect(errors.details[:attribute]).to eql [{ error: :invalid }]
+      context 'that is a string' do
+        let(:message) { SecureRandom.hex }
+
+        before do
+          other.add(:base, message)
+        end
+
+        it 'adds the error' do
+          errors.merge!(other)
+          expect(errors.details[:base]).to eql [{ error: message }]
+        end
       end
     end
 


### PR DESCRIPTION
This only occurs when errors that are strings are added to `:base` and then composed into another interaction.

fixes #349 