### PR TITLE
Upgrade to RuboCop 0.36

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,8 +13,6 @@ Documentation:
 FileName:
   Exclude:
   - gemfiles/*
-HandleExceptions:
-  Enabled: false
 MultilineOperationIndentation:
   Enabled: false
 PercentLiteralDelimiters:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,8 @@ Documentation:
 FileName:
   Exclude:
   - gemfiles/*
+MultilineMethodCallIndentation:
+  EnforcedStyle: indented
 MultilineOperationIndentation:
   Enabled: false
 PercentLiteralDelimiters:

--- a/active_interaction.gemspec
+++ b/active_interaction.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |gem|
     'kramdown' => ['~> 1.9'],
     'rake' => ['~> 10.4'],
     'rspec' => ['~> 3.4'],
-    'rubocop' => ['~> 0.35'],
+    'rubocop' => ['~> 0.36.0'],
     'yard' => ['~> 0.8']
   }.each do |name, versions|
     gem.add_development_dependency name, *versions

--- a/benchmarks/filters.rb
+++ b/benchmarks/filters.rb
@@ -18,7 +18,7 @@ VALUES = {
   string: '',
   symbol: :'',
   time: Time.at(0)
-}
+}.freeze
 
 Benchmark.ips do |bm|
   bm.report('lambda') { -> {}.call }

--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -254,7 +254,7 @@ module ActiveInteraction
         begin
           public_send("#{name}=", filter.clean(inputs[name], self))
         rescue InvalidValueError, MissingValueError, NoDefaultError
-          # #type_check will add errors if appropriate.
+          nil # #type_check will add errors if appropriate.
         end
       end
     end

--- a/lib/active_interaction/filter.rb
+++ b/lib/active_interaction/filter.rb
@@ -14,7 +14,7 @@ module ActiveInteraction
   # Describes an input filter for an interaction.
   class Filter
     # @return [Hash{Symbol => Class}]
-    CLASSES = {}
+    CLASSES = {} # rubocop:disable Style/MutableConstant
     private_constant :CLASSES
 
     # @return [Hash{Symbol => Filter}]

--- a/lib/active_interaction/filters/abstract_date_time_filter.rb
+++ b/lib/active_interaction/filters/abstract_date_time_filter.rb
@@ -9,7 +9,7 @@ module ActiveInteraction
   #
   # @private
   class AbstractDateTimeFilter < AbstractFilter
-    alias_method :_cast, :cast
+    alias _cast cast
     private :_cast
 
     def cast(value, context)

--- a/lib/active_interaction/filters/abstract_numeric_filter.rb
+++ b/lib/active_interaction/filters/abstract_numeric_filter.rb
@@ -8,7 +8,7 @@ module ActiveInteraction
   #
   # @private
   class AbstractNumericFilter < AbstractFilter
-    alias_method :_cast, :cast
+    alias _cast cast
     private :_cast
 
     def cast(value, context)

--- a/lib/active_interaction/filters/time_filter.rb
+++ b/lib/active_interaction/filters/time_filter.rb
@@ -24,7 +24,7 @@ module ActiveInteraction
   class TimeFilter < AbstractDateTimeFilter
     register :time
 
-    alias_method :_klass, :klass
+    alias _klass klass
     private :_klass
 
     def initialize(name, options = {}, &block)

--- a/spec/active_interaction/base_spec.rb
+++ b/spec/active_interaction/base_spec.rb
@@ -36,7 +36,7 @@ describe ActiveInteraction::Base do
   describe '.new(inputs = {})' do
     it 'does not allow :_interaction_* as an option' do
       key = :"_interaction_#{SecureRandom.hex}"
-      inputs.merge!(key => nil)
+      inputs[key] = nil
       expect do
         interaction
       end.to raise_error ActiveInteraction::InvalidValueError
@@ -44,7 +44,7 @@ describe ActiveInteraction::Base do
 
     it 'does not allow "_interaction_*" as an option' do
       key = "_interaction_#{SecureRandom.hex}"
-      inputs.merge!(key => nil)
+      inputs[key] = nil
       expect do
         interaction
       end.to raise_error ActiveInteraction::InvalidValueError
@@ -75,7 +75,7 @@ describe ActiveInteraction::Base do
         end
 
         context 'passing' do
-          before { inputs.merge!(thing: SecureRandom.hex) }
+          before { inputs[:thing] = SecureRandom.hex }
 
           it 'returns a valid outcome' do
             expect(interaction).to be_valid
@@ -85,7 +85,7 @@ describe ActiveInteraction::Base do
 
       context 'with a single input' do
         let(:thing) { SecureRandom.hex }
-        before { inputs.merge!(thing: thing) }
+        before { inputs[:thing] = thing }
 
         it 'sets the attribute' do
           expect(interaction.thing).to eql thing
@@ -98,7 +98,7 @@ describe ActiveInteraction::Base do
 
       context 'validation' do
         context 'failing' do
-          before { inputs.merge!(thing: thing) }
+          before { inputs[:thing] = thing }
 
           context 'with an invalid value' do
             let(:thing) { 'a' }
@@ -118,7 +118,7 @@ describe ActiveInteraction::Base do
         end
 
         context 'passing' do
-          before { inputs.merge!(thing: 1) }
+          before { inputs[:thing] = 1 }
 
           it 'returns a valid outcome' do
             expect(interaction).to be_valid
@@ -127,7 +127,7 @@ describe ActiveInteraction::Base do
       end
 
       context 'with a single input' do
-        before { inputs.merge!(thing: 1) }
+        before { inputs[:thing] = 1 }
 
         it 'sets the attribute to the filtered value' do
           expect(interaction.thing).to eql 1.0
@@ -248,7 +248,7 @@ describe ActiveInteraction::Base do
       end
 
       context 'passing validations' do
-        before { inputs.merge!(thing: thing) }
+        before { inputs[:thing] = thing }
 
         context 'failing runtime validations' do
           before do
@@ -311,7 +311,7 @@ describe ActiveInteraction::Base do
       end
 
       context 'passing validations' do
-        before { inputs.merge!(thing: thing) }
+        before { inputs[:thing] = thing }
 
         it 'returns the result' do
           expect(result[:thing]).to eql thing
@@ -341,7 +341,8 @@ describe ActiveInteraction::Base do
 
     context 'with valid composition' do
       before do
-        inputs.merge!(x: x, z: z)
+        inputs[:x] = x
+        inputs[:z] = z
       end
 
       it 'is valid' do
@@ -485,7 +486,7 @@ describe ActiveInteraction::Base do
       let(:thing) { rand }
 
       before do
-        inputs.merge!(thing: thing)
+        inputs[:thing] = thing
       end
 
       it 'returns true' do

--- a/spec/active_interaction/concerns/runnable_spec.rb
+++ b/spec/active_interaction/concerns/runnable_spec.rb
@@ -90,7 +90,7 @@ describe ActiveInteraction::Runnable do
     let(:result) { double }
 
     it 'returns the result' do
-      expect(instance.result = result).to eql result
+      expect((instance.result = result)).to eql result
     end
 
     it 'sets the result' do

--- a/spec/active_interaction/filters/date_filter_spec.rb
+++ b/spec/active_interaction/filters/date_filter_spec.rb
@@ -10,7 +10,7 @@ describe ActiveInteraction::DateFilter, :filter do
     let(:format) { '%d/%m/%Y' }
 
     before do
-      options.merge!(format: format)
+      options[:format] = format
     end
   end
 
@@ -116,12 +116,10 @@ describe ActiveInteraction::DateFilter, :filter do
   describe '#default' do
     context 'with a GroupedInput' do
       before do
-        options.merge!(
-          default: ActiveInteraction::GroupedInput.new(
-            '1' => '2012',
-            '2' => '1',
-            '3' => '2'
-          )
+        options[:default] = ActiveInteraction::GroupedInput.new(
+          '1' => '2012',
+          '2' => '1',
+          '3' => '2'
         )
       end
 

--- a/spec/active_interaction/filters/date_time_filter_spec.rb
+++ b/spec/active_interaction/filters/date_time_filter_spec.rb
@@ -10,7 +10,7 @@ describe ActiveInteraction::DateTimeFilter, :filter do
     let(:format) { '%d/%m/%Y %H:%M:%S %:z' }
 
     before do
-      options.merge!(format: format)
+      options[:format] = format
     end
   end
 
@@ -124,15 +124,13 @@ describe ActiveInteraction::DateTimeFilter, :filter do
   describe '#default' do
     context 'with a GroupedInput' do
       before do
-        options.merge!(
-          default: ActiveInteraction::GroupedInput.new(
-            '1' => '2012',
-            '2' => '1',
-            '3' => '2',
-            '4' => '3',
-            '5' => '4',
-            '6' => '5'
-          )
+        options[:default] = ActiveInteraction::GroupedInput.new(
+          '1' => '2012',
+          '2' => '1',
+          '3' => '2',
+          '4' => '3',
+          '5' => '4',
+          '6' => '5'
         )
       end
 

--- a/spec/active_interaction/filters/decimal_filter_spec.rb
+++ b/spec/active_interaction/filters/decimal_filter_spec.rb
@@ -10,7 +10,7 @@ describe ActiveInteraction::DecimalFilter, :filter do
     let(:digits) { 4 }
 
     before do
-      options.merge!(digits: digits)
+      options[:digits] = digits
     end
   end
 

--- a/spec/active_interaction/filters/hash_filter_spec.rb
+++ b/spec/active_interaction/filters/hash_filter_spec.rb
@@ -80,7 +80,7 @@ describe ActiveInteraction::HashFilter, :filter do
   describe '#default' do
     context 'with a Hash' do
       before do
-        options.merge!(default: {})
+        options[:default] = {}
       end
 
       it 'returns the Hash' do
@@ -90,7 +90,7 @@ describe ActiveInteraction::HashFilter, :filter do
 
     context 'with a non-empty Hash' do
       before do
-        options.merge!(default: { a: {} })
+        options[:default] = { a: {} }
       end
 
       it 'raises an error' do

--- a/spec/active_interaction/filters/object_filter_spec.rb
+++ b/spec/active_interaction/filters/object_filter_spec.rb
@@ -10,7 +10,7 @@ describe ActiveInteraction::ObjectFilter, :filter do
   it_behaves_like 'a filter'
 
   before do
-    options.merge!(class: Thing)
+    options[:class] = Thing
   end
 
   describe '#cast' do
@@ -101,7 +101,7 @@ describe ActiveInteraction::ObjectFilter, :filter do
 
     context 'with class as a superclass' do
       before do
-        options.merge!(class: Thing.superclass)
+        options[:class] = Thing.superclass
       end
 
       it 'returns the instance' do
@@ -111,7 +111,7 @@ describe ActiveInteraction::ObjectFilter, :filter do
 
     context 'with class as a String' do
       before do
-        options.merge!(class: Thing.name)
+        options[:class] = Thing.name
       end
 
       it 'returns the instance' do
@@ -131,7 +131,7 @@ describe ActiveInteraction::ObjectFilter, :filter do
 
     context 'with class as an invalid String' do
       before do
-        options.merge!(class: 'invalid')
+        options[:class] = 'invalid'
       end
 
       it 'raises an error' do

--- a/spec/active_interaction/filters/string_filter_spec.rb
+++ b/spec/active_interaction/filters/string_filter_spec.rb
@@ -8,7 +8,7 @@ describe ActiveInteraction::StringFilter, :filter do
 
   shared_context 'without strip' do
     before do
-      options.merge!(strip: false)
+      options[:strip] = false
     end
   end
 

--- a/spec/active_interaction/filters/time_filter_spec.rb
+++ b/spec/active_interaction/filters/time_filter_spec.rb
@@ -10,7 +10,7 @@ describe ActiveInteraction::TimeFilter, :filter do
     let(:format) { '%d/%m/%Y %H:%M:%S %z' }
 
     before do
-      options.merge!(format: format)
+      options[:format] = format
     end
   end
 
@@ -146,15 +146,13 @@ describe ActiveInteraction::TimeFilter, :filter do
   describe '#default' do
     context 'with a GroupedInput' do
       before do
-        options.merge!(
-          default: ActiveInteraction::GroupedInput.new(
-            '1' => '2012',
-            '2' => '1',
-            '3' => '2',
-            '4' => '3',
-            '5' => '4',
-            '6' => '5'
-          )
+        options[:default] = ActiveInteraction::GroupedInput.new(
+          '1' => '2012',
+          '2' => '1',
+          '3' => '2',
+          '4' => '3',
+          '5' => '4',
+          '6' => '5'
         )
       end
 

--- a/spec/active_interaction/integration/array_interaction_spec.rb
+++ b/spec/active_interaction/integration/array_interaction_spec.rb
@@ -31,7 +31,7 @@ describe ArrayInteraction do
   context 'with inputs[:a]' do
     let(:a) { [[]] }
 
-    before { inputs.merge!(a: a) }
+    before { inputs[:a] = a }
 
     it 'returns the correct value for :a' do
       expect(result[:a]).to eql a

--- a/spec/active_interaction/integration/hash_interaction_spec.rb
+++ b/spec/active_interaction/integration/hash_interaction_spec.rb
@@ -18,7 +18,7 @@ describe HashInteraction do
   context 'with inputs[:a]' do
     let(:a) { { x: {} } }
 
-    before { inputs.merge!(a: a) }
+    before { inputs[:a] = a }
 
     it 'returns the correct value for :a' do
       expect(result[:a]).to eql a.with_indifferent_access

--- a/spec/active_interaction/integration/time_interaction_spec.rb
+++ b/spec/active_interaction/integration/time_interaction_spec.rb
@@ -37,7 +37,7 @@ describe TimeInteraction do
     let(:a) { nil }
 
     before do
-      inputs.merge!(a: a)
+      inputs[:a] = a
 
       allow(Time).to receive(:zone).and_return(TimeZone)
     end

--- a/spec/active_interaction/integration/time_interaction_spec.rb
+++ b/spec/active_interaction/integration/time_interaction_spec.rb
@@ -10,6 +10,7 @@ TimeZone = Class.new do
   def self.parse(*args)
     TimeWithZone.new(Time.parse(*args))
   rescue ArgumentError
+    nil
   end
 end
 

--- a/spec/support/filters.rb
+++ b/spec/support/filters.rb
@@ -9,7 +9,7 @@ shared_context 'filters' do
 
   shared_context 'optional' do
     before do
-      options.merge!(default: nil)
+      options[:default] = nil
     end
   end
 
@@ -112,7 +112,7 @@ shared_examples_for 'a filter' do
 
     context 'with an invalid default' do
       before do
-        options.merge!(default: Object.new)
+        options[:default] = Object.new
       end
 
       it 'raises an error' do
@@ -144,7 +144,7 @@ shared_examples_for 'a filter' do
 
     context 'with an invalid default' do
       before do
-        options.merge!(default: Object.new)
+        options[:default] = Object.new
       end
 
       it 'raises an error' do
@@ -177,7 +177,7 @@ shared_examples_for 'a filter' do
       let(:desc) { SecureRandom.hex }
 
       before do
-        options.merge!(desc: desc)
+        options[:desc] = desc
       end
 
       it 'returns the description' do

--- a/spec/support/interactions.rb
+++ b/spec/support/interactions.rb
@@ -54,7 +54,7 @@ shared_examples_for 'an interaction' do |type, generator, filter_options = {}|
   context 'with inputs[:required]' do
     let(:required) { generator.call }
 
-    before { inputs.merge!(required: required) }
+    before { inputs[:required] = required }
 
     it 'is valid' do
       expect(outcome).to be_valid
@@ -73,7 +73,7 @@ shared_examples_for 'an interaction' do |type, generator, filter_options = {}|
     end
 
     it 'does not return nil for :default when given nil' do
-      inputs.merge!(default: nil)
+      inputs[:default] = nil
       expect(result[:default]).to_not be_nil
     end
 
@@ -92,7 +92,7 @@ shared_examples_for 'an interaction' do |type, generator, filter_options = {}|
     context 'with inputs[:optional]' do
       let(:optional) { generator.call }
 
-      before { inputs.merge!(optional: optional) }
+      before { inputs[:optional] = optional }
 
       it 'returns the correct value for :optional' do
         expect(result[:optional]).to eql optional
@@ -102,7 +102,7 @@ shared_examples_for 'an interaction' do |type, generator, filter_options = {}|
     context 'with inputs[:default]' do
       let(:default) { generator.call }
 
-      before { inputs.merge!(default: default) }
+      before { inputs[:default] = default }
 
       it 'returns the correct value for :default' do
         expect(result[:default]).to eql default


### PR DESCRIPTION
This pul request updates us to [RuboCop 0.36.0](https://github.com/bbatsov/rubocop/releases/tag/v0.36.0). It also changes the version specification from `~> 0.35` to `~> 0.36.0`. This should prevent the build from breaking when 0.37 comes out. 

I left one cop failing:

```
lib/active_interaction/filter.rb:17:15: C: Style/MutableConstant: Freeze mutable objects assigned to constants.
    CLASSES = {}
              ^^
```

There are a variety of ways we could fix this one. Or we could ignore the cop here. Not sure what to do.

@AaronLasseigne can you review this? 