### PR TITLE
Allow default lambdas to take a filter argument

### DIFF
--- a/lib/active_interaction/filter.rb
+++ b/lib/active_interaction/filter.rb
@@ -215,12 +215,9 @@ module ActiveInteraction
     # @return [Object]
     def raw_default(context)
       value = options.fetch(:default)
+      return value unless value.is_a?(Proc)
 
-      if value.is_a?(Proc)
-        context.instance_exec(&value)
-      else
-        value
-      end
+      context.instance_exec(&value)
     end
   end
 end

--- a/lib/active_interaction/filter.rb
+++ b/lib/active_interaction/filter.rb
@@ -217,7 +217,10 @@ module ActiveInteraction
       value = options.fetch(:default)
       return value unless value.is_a?(Proc)
 
-      context.instance_exec(&value)
+      case value.arity
+      when 1 then context.instance_exec(self, &value)
+      else context.instance_exec(&value)
+      end
     end
   end
 end

--- a/spec/support/filters.rb
+++ b/spec/support/filters.rb
@@ -166,6 +166,23 @@ shared_examples_for 'a filter' do
         expect(filter.default(nil)).to eql options[:default].call
       end
     end
+
+    context 'with a callable default that takes an argument' do
+      include_context 'optional'
+
+      it 'returns the default' do
+        default = options[:default]
+
+        spec = self
+        filter # Necessary to bring into scope for lambda.
+        options[:default] = lambda do |this|
+          spec.expect(this).to be filter
+          default
+        end
+
+        expect(filter.default(nil)).to be default
+      end
+    end
   end
 
   describe '#desc' do


### PR DESCRIPTION
This fixes #357. It changes the default lambda to allow taking a filter argument. If the lambda has arity 0 (that is, it takes no arguments), it will continue to work as before. If it has arity 1, it will be passed the filter that it is a default for.

``` rb
# As before.
boolean :x, default: -> { false }
# New!
boolean :y, default: -> (filter) { p filter.name; true }
# That will output ":y" when the default is evaluated.
```