### PR TITLE
Creating translation for pt-BR language

### DIFF
--- a/lib/active_interaction/locale/pt-BR.yml
+++ b/lib/active_interaction/locale/pt-BR.yml
@@ -1,0 +1,23 @@
+pt-BR:
+  active_interaction:
+    errors:
+      messages:
+        invalid: é inválido
+        invalid_nested: possui um valor aninhado inválido (%{name} => %{value})
+        invalid_type: não é um(a) %{type} válido(a)
+        missing: é obrigatório
+    types:
+      array: array
+      boolean: boolean
+      date: date
+      date_time: date time
+      decimal: decimal
+      file: file
+      float: float
+      hash: hash
+      integer: integer
+      interface: interface
+      object: object
+      string: string
+      symbol: symbol
+      time: time

--- a/spec/active_interaction/i18n_spec.rb
+++ b/spec/active_interaction/i18n_spec.rb
@@ -4,9 +4,9 @@ require 'spec_helper'
 
 describe ActiveInteraction do
   context 'I18n.load_path' do
-    it 'contains localization file paths at the beginning' do
+    it 'contains localization file paths at the beginning (second in list)' do
       expect(
-        I18n.load_path.first
+        I18n.load_path.second
       ).to match %r{active_interaction/locale/en.yml\z}
     end
   end
@@ -66,6 +66,17 @@ describe I18nInteraction do
     before do
       @locale = I18n.locale
       I18n.locale = :en
+    end
+
+    after { I18n.locale = @locale }
+  end
+
+  context 'brazilian portuguese' do
+    include_examples 'translation'
+
+    before do
+      @locale = I18n.locale
+      I18n.locale = :'pt-BR'
     end
 
     after { I18n.locale = @locale }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ Coveralls.wear!
 require 'i18n'
 if I18n.config.respond_to?(:enforce_available_locales)
   I18n.config.enforce_available_locales = true
-  I18n.config.available_locales = %w[en hsilgne]
+  I18n.config.available_locales = %w[en hsilgne pt-BR]
 end
 
 require 'active_interaction'


### PR DESCRIPTION
- Cloned en.yml file and translated available keys (except for the "types" collection)
- Change the test "contains localization file paths..." to now get the 2nd file in the
path, because the pt-BR file appears before (I guess it's because of the dash and upper
letters)
- Duplicated the english translation test and switched the context to brazilian portuguese
- Added the pt-BR language to the available locales in spec_helper.rb

If anything is missing, please, ping me and I'll fix it.

I didn't translated the types collection, to match the fr.yml translation.