### PR TITLE
Allow callbacks to interact with failures from composed interactions

### DIFF
--- a/lib/active_interaction/concerns/runnable.rb
+++ b/lib/active_interaction/concerns/runnable.rb
@@ -74,8 +74,8 @@ module ActiveInteraction
     def run
       return unless valid?
 
-      result_or_errors = catch(:interrupt) do
-        run_callbacks(:execute) { execute }
+      result_or_errors = run_callbacks(:execute) do
+        catch(:interrupt) { execute }
       end
 
       self.result =


### PR DESCRIPTION
Before this change, if a composed interaction failed, neither around nor after callbacks would be yielded to.