### PR TITLE
Throw an error for all reserved input names.

### DIFF
--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -107,7 +107,9 @@ module ActiveInteraction
       # @param name [Symbol]
       # @param options [Hash]
       def add_filter(klass, name, options, &block)
-        raise InvalidFilterError, name.inspect if InputProcessor.reserved?(name)
+        if InputProcessor.reserved?(name)
+          raise InvalidFilterError, %("#{name}" is a reserved name)
+        end
 
         initialize_filter(klass.new(name, options, &block))
       end

--- a/lib/active_interaction/modules/input_processor.rb
+++ b/lib/active_interaction/modules/input_processor.rb
@@ -14,7 +14,8 @@ module ActiveInteraction
 
       def reserved?(name)
         name.to_s.start_with?('_interaction_') ||
-          Base.instance_methods.include?(name)
+          Base.instance_methods.include?(name) ||
+          Base.private_instance_methods.include?(name)
       end
 
       def process(inputs)

--- a/lib/active_interaction/modules/input_processor.rb
+++ b/lib/active_interaction/modules/input_processor.rb
@@ -13,7 +13,8 @@ module ActiveInteraction
       private_constant :GROUPED_INPUT_PATTERN
 
       def reserved?(name)
-        name.to_s.start_with?('_interaction_')
+        name.to_s.start_with?('_interaction_') ||
+          Base.instance_methods.include?(name)
       end
 
       def process(inputs)

--- a/spec/active_interaction/modules/input_processor_spec.rb
+++ b/spec/active_interaction/modules/input_processor_spec.rb
@@ -9,7 +9,10 @@ describe ActiveInteraction::InputProcessor do
     end
 
     it 'returns true for existing instance methods' do
-      ActiveInteraction::Base.instance_methods.each do |method|
+      (
+        ActiveInteraction::Base.instance_methods +
+        ActiveInteraction::Base.private_instance_methods
+      ).each do |method|
         expect(described_class.reserved?(method)).to be_truthy
       end
     end

--- a/spec/active_interaction/modules/input_processor_spec.rb
+++ b/spec/active_interaction/modules/input_processor_spec.rb
@@ -8,6 +8,12 @@ describe ActiveInteraction::InputProcessor do
       expect(described_class.reserved?('_interaction_')).to be_truthy
     end
 
+    it 'returns true for existing instance methods' do
+      ActiveInteraction::Base.instance_methods.each do |method|
+        expect(described_class.reserved?(method)).to be_truthy
+      end
+    end
+
     it 'returns false for anything else' do
       expect(described_class.reserved?(SecureRandom.hex)).to be_falsey
     end


### PR DESCRIPTION
This closes #375.