### PR TITLE
WIP - Add the ability to group filters by a name

### DIFF
--- a/lib/active_interaction/errors.rb
+++ b/lib/active_interaction/errors.rb
@@ -38,6 +38,11 @@ module ActiveInteraction
   # @return [Class]
   MissingFilterError = Class.new(Error)
 
+  # Raised if a group cannot be found.
+  #
+  # @return [Class]
+  MissingGroupError = Class.new(Error)
+
   # Raised if no value is given.
   #
   # @return [Class]


### PR DESCRIPTION
I would like to propose a way of grouping inputs so they are easily accessible later in the code execution.

I often find myself doing the following

```
class UpdateService < ActiveInteraction::Base
  string :a
  string :b
  integer :c
  object :object
  interface :dependency_a, methods: [:call], default: DepedencyA.new

  def execute
     update_params = inputs.except(:object, :dependency_a)
     object.update_attributes(update_params)
     dependency_a.call(object)
    # Do some other interesting stuff 
  end
end
```

What I would like to do is have the ability to group my inputs with some kind of tag which would allow me to access a subset of the inputs. The reasons behind this is that I often find myself coming back to an interaction and adding new filters and either forgetting to add them or remove them from the params I am updating the model with.

This PR is a POC to be able to do just that, for example it will allow me to add a group option ( tag may be a better name ) to each of the filters

```
class UpdateService < ActiveInteraction::Base
  string :a, group: :update_params
  string :b, group: :update_params
  integer :c, group: :update_params
  object :object
  interface :dependency_a, methods: [:call], default: DepedencyA.new

  def execute
     object.update_attributes(inputs(:update_params))
     dependency_a.call(object)
    # Do some other interesting stuff
  end
end
```

Which gets even nicer when you use grouped inputs

```
class UpdateService < ActiveInteraction::Base
  with_options group: :update_params do
    string :a
    string :b
    integer :c
  end
  object :object
  interface :dependency_a, methods: [:call], default: DepedencyA.new

  def execute
     object.update_attributes(inputs(:update_params))
     dependency_a.call(object)
     # Do some other interesting stuff
  end
end
```

What are peoples thoughts around such an approach? I did initially try this with grouping the inputs within a hash e.g

```
hash: :update_params do
  string :a
  string :b
  integer :c
end
```

Although this prevented a lot of the nice built in features you gain e.g. validations that you get with passing in the params flattened as suggested in the docs.

I will add specs and docs if the maintainers are happy with this approach

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/orgsync/active_interaction/390)

<!-- Reviewable:end -->
