### PR TITLE
make given? capable of checking hash filter keys too

### DIFF
--- a/README.md
+++ b/README.md
@@ -1267,7 +1267,8 @@ are merged to create `inputs`. There are times where it is useful to know
 whether a value was passed to `run` or the result of a filter default. In
 particular, it is useful when `nil` is an acceptable value. For example, you
 may optionally track your users' birthdays. You can use the `given?` predicate
-to see if an input was even passed to `run`.
+to see if an input was even passed to `run`. With `given?` you can also check
+the input of a hash filter by passing a series of keys to check.
 
 ``` rb
 class UpdateUser < ActiveInteraction::Base

--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -203,7 +203,8 @@ module ActiveInteraction
 
     # Returns `true` if the given key was in the hash passed to {.run}.
     # Otherwise returns `false`. Use this to figure out if an input was given,
-    # even if it was `nil`.
+    # even if it was `nil`. Keys within nested hash filter can also be checked
+    # by passing them in series.
     #
     # @example
     #   class Example < ActiveInteraction::Base
@@ -214,13 +215,35 @@ module ActiveInteraction
     #   Example.run!(x: nil)  # => true
     #   Example.run!(x: rand) # => true
     #
+    # @example Nested checks
+    #   class Example < ActiveInteraction::Base
+    #     hash :x, default: {} do
+    #       integer :y, default: nil
+    #     end
+    #     def execute; given?(:x, :y) end
+    #   end
+    #   Example.run!()               # => false
+    #   Example.run!(x: nil)         # => false
+    #   Example.run!(x: {})          # => false
+    #   Example.run!(x: { y: rand }) # => true
+    #
     # @param input [#to_sym]
     #
     # @return [Boolean]
     #
     # @since 2.1.0
-    def given?(input)
-      @_interaction_keys.include?(input.to_sym)
+    def given?(input, *rest)
+      filter_level = self.class
+      input_level = @_interaction_inputs
+
+      [input, *rest].map(&:to_sym).each do |key|
+        filter_level = filter_level.filters[key]
+        if !filter_level || input_level.nil? || !input_level.key?(key)
+          break false
+        end
+
+        input_level = input_level[key]
+      end && true
     end
 
     protected
@@ -250,7 +273,7 @@ module ActiveInteraction
 
     # @param inputs [Hash{Symbol => Object}]
     def process_inputs(inputs)
-      @_interaction_keys = inputs.keys.to_set & self.class.filters.keys
+      @_interaction_inputs = inputs
 
       inputs.each do |key, value|
         raise InvalidValueError, key.inspect if InputProcessor.reserved?(key)

--- a/lib/active_interaction/base.rb
+++ b/lib/active_interaction/base.rb
@@ -225,6 +225,7 @@ module ActiveInteraction
     #   Example.run!()               # => false
     #   Example.run!(x: nil)         # => false
     #   Example.run!(x: {})          # => false
+    #   Example.run!(x: { y: nil })  # => true
     #   Example.run!(x: { y: rand }) # => true
     #
     # @param input [#to_sym]

--- a/spec/active_interaction/base_spec.rb
+++ b/spec/active_interaction/base_spec.rb
@@ -491,6 +491,17 @@ describe ActiveInteraction::Base do
         inputs[:x] = nil
         expect(result).to be false
       end
+
+      it 'returns false if you go too far' do
+        described_class.class_exec do
+          def execute
+            given?(:x, :y, :z)
+          end
+        end
+
+        inputs[:x] = { y: true }
+        expect(result).to be false
+      end
     end
   end
 

--- a/spec/active_interaction/base_spec.rb
+++ b/spec/active_interaction/base_spec.rb
@@ -436,6 +436,62 @@ describe ActiveInteraction::Base do
       inputs[:y] = rand
       expect(result).to be false
     end
+
+    context 'nested hash values' do
+      let(:described_class) do
+        Class.new(TestInteraction) do
+          hash :x, default: {} do
+            boolean :y,
+              default: true
+          end
+
+          def execute; end
+        end
+      end
+
+      it 'is true when the nested input is given' do
+        described_class.class_exec do
+          def execute
+            given?(:x, :y)
+          end
+        end
+
+        inputs[:x] = { y: false }
+        expect(result).to be true
+      end
+
+      it 'is false when the nested input is not given' do
+        described_class.class_exec do
+          def execute
+            given?(:x, :y)
+          end
+        end
+
+        inputs[:x] = {}
+        expect(result).to be false
+      end
+
+      it 'is false when the first input is not given' do
+        described_class.class_exec do
+          def execute
+            given?(:x, :y)
+          end
+        end
+
+        expect(result).to be false
+      end
+
+      it 'is false when the first input is nil' do
+        described_class.class_exec do
+          def execute
+            given?(:x, :y)
+          end
+        end
+
+        inputs[:x] = nil
+        expect(result).to be false
+      end
+    end
   end
 
   context 'inheritance' do


### PR DESCRIPTION
closes #408

After some thought, I don't think `given?` should work on arrays. The goal of `given?` is to determine whether an optional input was passed. With arrays we don't have optional entries in the array.