### PR TITLE
default the integer base to 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,24 +604,27 @@ IntegerInteraction.run!(limit: 10)
 ```
 
 When a `String` is passed into an `integer` input, the value will be coerced.
-Coercion is based on `Kernel#Integer` which attempts to detect the base being used.
-However, you may want to specify the `base` for the conversion to something more
-sensible (e.g. `base: 10`).
+A default base of `10` is used though it may be overridden with the `base` option.
+If a base of `0` is provided, the coercion will respect radix indicators present
+in the string.
 
 ``` rb
 class IntegerInteraction < ActiveInteraction::Base
-  integer :limit1, base: 10
-  integer :limit2
-
+  integer :limit1
+  integer :limit2, base: 8
+  integer :limit3, base: 0
+  
   def execute
-    [limit1, limit2]
+    [limit1, limit2, limit3]
   end
 end
 
-IntegerInteraction.run!(limit1: "08", limit2: 8)
-# => [8, 8]
-IntegerInteraction.run!(limit1: "08", limit2: "08")
-# ArgumentError: invalid value for Integer(): "08"
+IntegerInteraction.run!(limit1: 71, limit2: 71, limit3: 71)
+# => [71, 71, 71]
+IntegerInteraction.run!(limit1: "071", limit2: "071", limit3: "0x71")
+# => [71, 57, 113]
+IntegerInteraction.run!(limit1: "08", limit2: "08", limit3: "08")
+ActiveInteraction::InvalidInteractionError: Limit2 is not a valid integer, Limit3 is not a valid integer
 ```
 
 ## Rails

--- a/lib/active_interaction/filters/integer_filter.rb
+++ b/lib/active_interaction/filters/integer_filter.rb
@@ -9,6 +9,9 @@ module ActiveInteraction
     #     Integers.
     #
     #   @!macro filter_method_params
+    #   @option options [Integer] :base (10) The base used to convert strings
+    #     into integers. When set to `0` it will honor radix indicators (i.e.
+    #     0, 0b, and 0x).
     #
     #   @example
     #     integer :quantity
@@ -22,11 +25,11 @@ module ActiveInteraction
 
     # @return [Integer]
     def base
-      options.fetch(:base, 0)
+      options.fetch(:base, 10)
     end
 
     def convert(value, context)
-      Integer(value, base)
+      Integer(value, value.is_a?(String) ? base : 0)
     rescue ArgumentError
       _cast(value, context)
     end

--- a/spec/active_interaction/filters/integer_filter_spec.rb
+++ b/spec/active_interaction/filters/integer_filter_spec.rb
@@ -26,10 +26,10 @@ describe ActiveInteraction::IntegerFilter, :filter do
     end
 
     context 'with a String' do
-      let(:value) { rand(1 << 16).to_s }
+      let(:value) { '0' + rand(1 << 16).to_s }
 
       it 'returns an Integer' do
-        expect(result).to eql Integer(value)
+        expect(result).to eql Integer(value, 10)
       end
     end
 
@@ -44,11 +44,10 @@ describe ActiveInteraction::IntegerFilter, :filter do
     end
 
     it 'supports different bases' do
-      expect(filter.cast('07', nil)).to eql 7
+      expect(described_class.new(name, base: 8).cast('071', nil)).to eql 57
       expect do
-        filter.cast('08', nil)
+        described_class.new(name, base: 8).cast('081', nil)
       end.to raise_error ActiveInteraction::InvalidValueError
-      expect(described_class.new(name, base: 10).cast('08', nil)).to eql 8
     end
   end
 


### PR DESCRIPTION
closes #392 

This only applies the `:base` option to strings that are being converted.